### PR TITLE
feat: add JUnit XML output support for CI/CD integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,12 @@ make test-unit              # Run only unit tests
 make test-integration       # Run only integration tests
 make test-unit-json         # Run unit tests with JSON output
 
+# JUnit XML output for CI/CD integration
+make test-junit             # Run all tests with JUnit XML output
+make test-ci                # Run tests for CI/CD (saves to test-results/junit.xml)
+make test-unit-junit        # Run unit tests with JUnit XML output
+make test-integration-junit # Run integration tests with JUnit XML output
+
 # Show all available commands
 make help
 ```
@@ -55,6 +61,9 @@ If you need more control or the Makefile doesn't meet your needs:
 
 # Run all tests with JSON output  
 /Applications/tool4d.app/Contents/MacOS/tool4d --project $(PWD)/testing/Project/testing.4DProject --skip-onstartup --dataless --startup-method "test" --user-param "format=json"
+
+# Run all tests with JUnit XML output (saves to test-results/junit.xml)
+/Applications/tool4d.app/Contents/MacOS/tool4d --project $(PWD)/testing/Project/testing.4DProject --skip-onstartup --dataless --startup-method "test" --user-param "format=junit"
 ```
 
 ### Test Filtering Parameters
@@ -72,6 +81,8 @@ If you need more control or the Makefile doesn't meet your needs:
 # Combined filtering
 --user-param "tags=unit excludeTags=slow"
 --user-param "format=json tags=integration"
+--user-param "format=junit tags=unit"
+--user-param "format=junit outputPath=results/junit.xml"
 ```
 
 ### Current Test Status
@@ -95,6 +106,71 @@ testing/Project/Sources/Classes/
 ```
 
 The framework automatically discovers and runs any class ending with "Test" that contains methods starting with "test_".
+
+## JUnit XML Output for CI/CD Integration
+
+The framework supports JUnit XML output format for integration with GitLab CI/CD and other continuous integration systems.
+
+### JUnit XML Features
+
+- **GitLab Integration**: Test results appear in merge requests and pipeline views
+- **File Artifacts**: XML files can be archived as CI artifacts for historical tracking
+- **Test Navigation**: Direct links to failing test files in GitLab UI
+- **Standard Format**: Compatible with Jenkins, CircleCI, and other CI tools
+- **Detailed Reporting**: Includes test timing, failure messages, and stack traces
+
+### Basic Usage
+
+```bash
+# Generate JUnit XML (saves to test-results/junit.xml)
+make test-junit
+
+# Custom output location
+make test format=junit outputPath=custom/path/results.xml
+
+# Combined with filtering
+make test-unit-junit                    # Unit tests only
+make test format=junit tags=integration # Integration tests only
+```
+
+### GitLab CI Integration
+
+Add this to your `.gitlab-ci.yml`:
+
+```yaml
+test:
+  script:
+    - make test-ci  # Generates test-results/junit.xml
+  artifacts:
+    reports:
+      junit: test-results/junit.xml
+    paths:
+      - test-results/
+    when: always
+    expire_in: 30 days
+  coverage: '/Lines:\s*(\d+\.?\d*)%/'
+```
+
+### JUnit XML Structure
+
+The generated XML includes:
+
+- **Test Suites**: One per test class
+- **Test Cases**: Individual test methods with timing
+- **Failures**: Detailed failure messages with location info
+- **File References**: Links to source test files
+- **Timestamps**: Test execution timing for performance tracking
+
+Example output structure:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="4D Test Results" tests="121" failures="0" errors="0" time="1.234">
+  <testsuite name="_ExampleTest" tests="5" failures="0" errors="0" time="0.156">
+    <testcase classname="_ExampleTest" name="test_areEqual_pass" 
+              file="testing/Project/Sources/Classes/_ExampleTest.4dm" time="0.023"/>
+  </testsuite>
+</testsuites>
+```
 
 ## Transaction Management
 

--- a/Makefile
+++ b/Makefile
@@ -60,12 +60,30 @@ test-integration:
 test-unit-json:
 	$(TOOL4D) $(BASE_OPTS) --user-param "format=json tags=unit"
 
+# Run all tests with JUnit XML output
+test-junit:
+	$(TOOL4D) $(BASE_OPTS) --user-param "format=junit"
+
+# Run tests for CI/CD with custom output path
+test-ci:
+	$(TOOL4D) $(BASE_OPTS) --user-param "format=junit outputPath=test-results/junit.xml"
+
+# Run unit tests with JUnit XML output
+test-unit-junit:
+	$(TOOL4D) $(BASE_OPTS) --user-param "format=junit tags=unit"
+
+# Run integration tests with JUnit XML output
+test-integration-junit:
+	$(TOOL4D) $(BASE_OPTS) --user-param "format=junit tags=integration"
+
 # Show help
 help:
 	@echo "4D Unit Testing Framework Commands:"
 	@echo ""
 	@echo "  test [params]       - Run tests with optional parameters"
 	@echo "  test-json           - Run all tests with JSON output"
+	@echo "  test-junit          - Run all tests with JUnit XML output"
+	@echo "  test-ci             - Run tests for CI/CD (JUnit XML to test-results/)"
 	@echo "  test-class          - Run specific test class (CLASS=ExampleTest)"
 	@echo "  test-tags           - Run tests by tags (TAGS=unit)"
 	@echo "  test-exclude-tags   - Run tests excluding tags (TAGS=slow)"
@@ -73,16 +91,22 @@ help:
 	@echo "  test-unit           - Run unit tests only"
 	@echo "  test-integration    - Run integration tests only"
 	@echo "  test-unit-json      - Run unit tests with JSON output"
+	@echo "  test-unit-junit     - Run unit tests with JUnit XML output"
+	@echo "  test-integration-junit - Run integration tests with JUnit XML output"
 	@echo "  help                - Show this help message"
 	@echo ""
 	@echo "Examples:"
 	@echo "  make test"
 	@echo "  make test format=json"
+	@echo "  make test format=junit"
 	@echo "  make test tags=unit"
 	@echo "  make test format=json tags=unit excludeTags=slow"
+	@echo "  make test format=junit outputPath=results/junit.xml"
 	@echo "  make test test=ExampleTest"
 	@echo "  make test-class CLASS=TaggingSystemTest"
 	@echo "  make test-tags TAGS=unit,fast"
 	@echo "  make test-exclude-tags TAGS=slow"
+	@echo "  make test-junit"
+	@echo "  make test-ci"
 
-.PHONY: test test-json test-class test-tags test-exclude-tags test-require-tags test-unit test-integration test-unit-json help
+.PHONY: test test-json test-junit test-ci test-class test-tags test-exclude-tags test-require-tags test-unit test-integration test-unit-json test-unit-junit test-integration-junit help

--- a/testing/Project/Sources/Classes/_JSONOutputTest.4dm
+++ b/testing/Project/Sources/Classes/_JSONOutputTest.4dm
@@ -148,7 +148,7 @@ Function test_output_format_setting($t : cs:C1710.Testing)
 	$runner:=cs:C1710.TestRunner.new()
 	
 	// Test that output format is set (depends on current user parameters)
-	$t.assert.isTrue($t; ($runner.outputFormat="human") || ($runner.outputFormat="json"); "Output format should be either human or json")
+	$t.assert.isTrue($t; ($runner.outputFormat="human") || ($runner.outputFormat="json") || ($runner.outputFormat="junit"); "Output format should be human, json, or junit")
 	
 	// We can't easily test format=json parameter parsing without mocking
 	// the Get database parameter call, but we can verify the format property exists

--- a/testing/Project/Sources/Classes/_ParameterParsingTest.4dm
+++ b/testing/Project/Sources/Classes/_ParameterParsingTest.4dm
@@ -11,7 +11,7 @@ Function test_parse_single_parameter($t : cs:C1710.Testing)
 	$runner:=cs:C1710.TestRunner.new()
 	
 	// Test that output format is set (depends on current user parameters)
-	$t.assert.isTrue($t; ($runner.outputFormat="human") || ($runner.outputFormat="json"); "Output format should be either human or json")
+	$t.assert.isTrue($t; ($runner.outputFormat="human") || ($runner.outputFormat="json") || ($runner.outputFormat="junit"); "Output format should be human, json, or junit")
 	$t.assert.areEqual($t; 0; $runner.testPatterns.length; "Should have no test patterns by default")
 
 Function test_pattern_parsing_logic($t : cs:C1710.Testing)

--- a/testing/Project/Sources/Classes/_TestRunnerTest.4dm
+++ b/testing/Project/Sources/Classes/_TestRunnerTest.4dm
@@ -96,7 +96,7 @@ Function test_output_format_defaults_to_human($t : cs:C1710.Testing)
 	
 	// Note: Output format depends on current user parameters when running tests
 	// This test verifies the outputFormat property exists and has a valid value
-	$t.assert.isTrue($t; ($runner.outputFormat="human") || ($runner.outputFormat="json"); "Output format should be either human or json")
+	$t.assert.isTrue($t; ($runner.outputFormat="human") || ($runner.outputFormat="json") || ($runner.outputFormat="junit"); "Output format should be human, json, or junit")
 	
 Function test_test_class_discovery($t : cs:C1710.Testing)
 	


### PR DESCRIPTION
- Introduced new Makefile commands for JUnit XML output: `test-junit`, `test-ci`, `test-unit-junit`, and `test-integration-junit`.
- Updated documentation in CLAUDE.md to include JUnit XML features and usage examples.
- Enhanced test output format validation to support "junit" alongside existing formats.
- Implemented JUnit XML report generation in TestRunner, including detailed test results and failure messages.

This update facilitates better integration with CI/CD systems like GitLab and Jenkins.