### PR TITLE
Tag Linux-incompatible test and improve cross-platform testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,19 @@
 # Get current user's home directory
 HOME_DIR := $(shell echo $$HOME)
 
-# 4D tool path
+# Determine operating system
+UNAME_S := $(shell uname -s)
+
+# 4D tool path and default exclusion tags
+ifeq ($(UNAME_S),Darwin)
 TOOL4D := /Applications/tool4d.app/Contents/MacOS/tool4d
+else
+TOOL4D := /opt/tool4d/tool4d
+DEFAULT_EXCLUDE_TAGS := no-linux
+endif
+
+# URL for downloading tool4d by platform
+TOOL4D_URL_LINUX := https://resources-download.4d.com/release/20%20Rx/latest/latest/linux/tool4d.deb
 
 # Project path relative to current directory
 PROJECT_PATH := $(PWD)/testing/Project/testing.4DProject
@@ -15,50 +26,74 @@ BASE_OPTS := --project $(PROJECT_PATH) --skip-onstartup --dataless --startup-met
 # Default target
 .DEFAULT_GOAL := test
 
-# Build user parameters from make variables
-USER_PARAMS := $(strip $(if $(format),format=$(format)) $(if $(tags),tags=$(tags)) $(if $(test),test=$(test)) $(if $(excludeTags),excludeTags=$(excludeTags)) $(if $(requireTags),requireTags=$(requireTags)))
+# Internal helpers for tag handling
+empty :=
+space := $(empty) $(empty)
+comma := ,
 
-# Run all tests with human-readable output  
+EXCLUDE_TAGS_COMBINED := $(strip $(DEFAULT_EXCLUDE_TAGS) $(excludeTags))
+BASE_PARAMS := $(if $(EXCLUDE_TAGS_COMBINED),excludeTags=$(subst $(space),$(comma),$(EXCLUDE_TAGS_COMBINED)))
+
+# Build user parameters from make variables
+USER_PARAMS := $(strip $(BASE_PARAMS) $(if $(format),format=$(format)) $(if $(tags),tags=$(tags)) $(if $(test),test=$(test)) $(if $(requireTags),requireTags=$(requireTags)))
+
+# Ensure tool4d is installed (currently implemented for Linux only)
+$(TOOL4D):
+	@echo "tool4d not found at $(TOOL4D). Installing..."
+	@if [ "$(UNAME_S)" = "Linux" ]; then \
+	        apt-get update && \
+	        apt-get install -y curl libc++1 uuid-runtime libfreeimage3 xdg-user-dirs; \
+	        curl -L -o /tmp/libtinfo5.deb http://archive.ubuntu.com/ubuntu/pool/main/n/ncurses/libtinfo5_6.1-1ubuntu1_amd64.deb; \
+	        curl -L -o /tmp/libncurses5.deb http://archive.ubuntu.com/ubuntu/pool/main/n/ncurses/libncurses5_6.1-1ubuntu1_amd64.deb; \
+	        dpkg -i /tmp/libtinfo5.deb /tmp/libncurses5.deb; \
+	        curl -L -o /tmp/tool4d.deb $(TOOL4D_URL_LINUX); \
+	        dpkg --force-depends -i /tmp/tool4d.deb; \
+	else \
+	        echo "Automatic installation for $(UNAME_S) not implemented. Please install tool4d manually."; \
+	        exit 1; \
+	fi
+
+# Run all tests with human-readable output
 # Usage: make test [key=value key2=value2 ...]
 # Example: make test format=json tags=unit
-test:
+test: $(TOOL4D)
 	@if [ -n "$(USER_PARAMS)" ]; then \
-		$(TOOL4D) $(BASE_OPTS) --user-param "$(USER_PARAMS)"; \
+	        $(TOOL4D) $(BASE_OPTS) --user-param "$(USER_PARAMS)"; \
 	else \
-		$(TOOL4D) $(BASE_OPTS); \
+	        $(TOOL4D) $(BASE_OPTS); \
 	fi
 
 # Run all tests with JSON output
 test-json:
-	$(TOOL4D) $(BASE_OPTS) --user-param "format=json"
+	$(MAKE) test format=json
 
 # Run specific test class (usage: make test-class CLASS=ExampleTest)
 test-class:
-	$(TOOL4D) $(BASE_OPTS) --user-param "test=$(CLASS)"
+	$(MAKE) test test=$(CLASS)
 
 # Run tests by tags (usage: make test-tags TAGS=unit)
 test-tags:
-	$(TOOL4D) $(BASE_OPTS) --user-param "tags=$(TAGS)"
+	$(MAKE) test tags=$(TAGS)
 
 # Run tests excluding tags (usage: make test-exclude-tags TAGS=slow)
 test-exclude-tags:
-	$(TOOL4D) $(BASE_OPTS) --user-param "excludeTags=$(TAGS)"
+	$(MAKE) test excludeTags=$(TAGS)
 
 # Run tests requiring specific tags (usage: make test-require-tags TAGS=unit,fast)
 test-require-tags:
-	$(TOOL4D) $(BASE_OPTS) --user-param "requireTags=$(TAGS)"
+	$(MAKE) test requireTags=$(TAGS)
 
 # Run unit tests only
 test-unit:
-	$(TOOL4D) $(BASE_OPTS) --user-param "tags=unit"
+	$(MAKE) test tags=unit
 
 # Run integration tests only
 test-integration:
-	$(TOOL4D) $(BASE_OPTS) --user-param "tags=integration"
+	$(MAKE) test tags=integration
 
 # Run tests with JSON output and unit tag
 test-unit-json:
-	$(TOOL4D) $(BASE_OPTS) --user-param "format=json tags=unit"
+	$(MAKE) test format=json tags=unit
 
 # Show help
 help:
@@ -84,5 +119,7 @@ help:
 	@echo "  make test-class CLASS=TaggingSystemTest"
 	@echo "  make test-tags TAGS=unit,fast"
 	@echo "  make test-exclude-tags TAGS=slow"
+tool4d: $(TOOL4D)
+	@echo "tool4d ready at $(TOOL4D)"
 
-.PHONY: test test-json test-class test-tags test-exclude-tags test-require-tags test-unit test-integration test-unit-json help
+.PHONY: test test-json test-class test-tags test-exclude-tags test-require-tags test-unit test-integration test-unit-json help tool4d

--- a/docs/running-tests-linux.md
+++ b/docs/running-tests-linux.md
@@ -1,0 +1,60 @@
+# Running 4D Unit Tests on Linux
+
+The repository now includes automated tooling to fetch and install the experimental Linux build of **tool4d** and its required dependencies. The `Makefile` handles everything for you.
+
+## Quick start
+
+```bash
+make test
+```
+
+On the first run this will:
+
+1. Install the libraries `libc++1`, `uuid-runtime`, `libfreeimage3`, `xdg-user-dirs`, `libtinfo5`, and `libncurses5` if they are missing.
+2. Download and install the latest Linux `tool4d` package to `/opt/tool4d`.
+3. Execute the project's test suite, automatically skipping tests tagged `no-linux`.
+
+You can also bootstrap the environment without running the tests:
+
+```bash
+make tool4d
+```
+
+Once the setup has completed, subsequent invocations of `make test` reuse the installed tooling and run quickly.
+
+## Manual installation
+
+The steps above are sufficient for most scenarios. If you need to perform the setup manually (for example, in a container without `make`), the commands executed by the `Makefile` are:
+
+```bash
+apt-get update
+apt-get install -y curl libc++1 uuid-runtime libfreeimage3 xdg-user-dirs
+curl -L -o /tmp/libtinfo5.deb http://archive.ubuntu.com/ubuntu/pool/main/n/ncurses/libtinfo5_6.1-1ubuntu1_amd64.deb
+curl -L -o /tmp/libncurses5.deb http://archive.ubuntu.com/ubuntu/pool/main/n/ncurses/libncurses5_6.1-1ubuntu1_amd64.deb
+dpkg -i /tmp/libtinfo5.deb /tmp/libncurses5.deb
+curl -L -o /tmp/tool4d.deb https://resources-download.4d.com/release/20%20Rx/latest/latest/linux/tool4d.deb
+dpkg --force-depends -i /tmp/tool4d.deb
+```
+
+After installation, run the tests manually:
+
+```bash
+/opt/tool4d/tool4d --project /workspace/testing/testing/Project/testing.4DProject \
+  --skip-onstartup --dataless --startup-method test \
+  --user-param "excludeTags=no-linux"
+```
+
+The output should end with a summary similar to:
+
+```
+=== Test Results Summary ===
+Total Tests: 131
+Passed: 131
+Failed: 0
+Pass Rate: 100.0%
+```
+
+## Notes
+- Tests tagged `no-linux` are excluded by default on Linux (for example, `_TaggingExampleTest.test_file_system_access`).
+- The Linux build runs headlessly and does **not** require Wine or a graphical environment.
+- Previous attempts to run the Windows build via Wine were unstable and are not recommended.

--- a/testing/Project/Sources/Classes/_TaggingExampleTest.4dm
+++ b/testing/Project/Sources/Classes/_TaggingExampleTest.4dm
@@ -35,10 +35,10 @@ Function test_parameter_validation($t : cs:C1710.Testing)
 	$result:=(Null:C1517=Null:C1517)
 	$t.assert.isTrue($t; $result; "Null comparison should work")
 
-// #tags: integration, external
+// #tags: integration, external, no-linux
 Function test_file_system_access($t : cs:C1710.Testing)
 	// Test file system access
 	var $folder : 4D:C1709.Folder
 	$folder:=Folder:C1567(fk desktop folder:K87:19)
 	$t.assert.isNotNull($t; $folder; "Should be able to access desktop folder")
-	$t.assert.isTrue($t; $folder.exists; "Desktop folder should exist")
+        $t.assert.isTrue($t; $folder.exists; "Desktop folder should exist")


### PR DESCRIPTION
## Summary
- Tag file-system test as `no-linux` so it can be skipped on Linux.
- Update Makefile to auto-detect OS, install Linux dependencies, download tool4d when missing, and apply default Linux exclusions.
- Document running tests via `make` with automatic setup and note Linux-specific tag filtering.

## Testing
- `make tool4d`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aa157da2c08324be3d6dc1b97c7075

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automated Linux setup for tool4d via make, with OS-aware detection and ready message.
  - Unified test commands (json, class, tags, exclude-tags, require-tags, unit, integration) routed through a single test target.
  - Improved help output with clearer commands and examples.

- Documentation
  - Added Linux testing guide detailing quick start, dependency installation, and manual invocation examples.

- Tests
  - Added no-linux tag to skip incompatible test on Linux by default.
  - Test targets now ensure tool availability before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->