### PR TITLE
Add skip tag support to unit testing framework

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -362,6 +362,20 @@ Function test_file_system_access($t : cs.Testing)
 - Whitespace around tags is automatically trimmed
 - Tests without explicit tags automatically receive the "unit" tag
 
+### Skipping Tests
+
+Mark a test with the `skip` tag to prevent it from running while still
+being reported in the overall test statistics:
+
+```4d
+// #tags: unit, skip
+Function test_pending_feature($t : cs.Testing)
+    $t.assert.fail($t; "This code is not ready")
+```
+
+Skipped tests are counted in the totals and listed separately, but they
+do not affect the pass rate.
+
 ### Tag Filtering Commands
 
 #### Include Tags (OR Logic)

--- a/testing/Project/Sources/Classes/_SkipTaggedTest.4dm
+++ b/testing/Project/Sources/Classes/_SkipTaggedTest.4dm
@@ -1,0 +1,6 @@
+// Test class with a skipped test to verify skip functionality
+Class constructor()
+
+// #tags: unit, skip
+Function test_should_be_skipped($t : cs:C1710.Testing)
+        $t.assert.fail($t; "This test should be skipped and not executed")

--- a/testing/Project/Sources/Classes/_TestFunction.4dm
+++ b/testing/Project/Sources/Classes/_TestFunction.4dm
@@ -6,6 +6,7 @@ property t : cs:C1710.Testing
 property startTime : Integer
 property endTime : Integer
 property runtimeErrors : Collection
+property skipped : Boolean
 property tags : Collection  // Collection of tag strings
 property useTransactions : Boolean  // Whether to auto-manage transactions for this test
 
@@ -13,24 +14,32 @@ Class constructor($class : 4D:C1709.Class; $classInstance : 4D:C1709.Object; $fu
 	This:C1470.class:=$class
 	This:C1470.classInstance:=$classInstance
 	This:C1470.function:=$function
-	This:C1470.functionName:=$name
-	This:C1470.t:=cs:C1710.Testing.new()
-	This:C1470.runtimeErrors:=[]
-	This:C1470.tags:=This:C1470._parseTags($classCode || "")
-	This:C1470.useTransactions:=This:C1470._shouldUseTransactions($classCode || "")
+        This:C1470.functionName:=$name
+        This:C1470.t:=cs:C1710.Testing.new()
+        This:C1470.runtimeErrors:=[]
+        This:C1470.skipped:=False:C215
+        This:C1470.tags:=This:C1470._parseTags($classCode || "")
+        This:C1470.useTransactions:=This:C1470._shouldUseTransactions($classCode || "")
 	
 Function run()
-	This:C1470.startTime:=Milliseconds:C459
-	
-	// Reset the testing context for this test
-	This:C1470.t.resetForNewTest()
-	
-	// Clear any existing test errors
-	If (Storage:C1525.testErrors#Null:C1517)
-		Use (Storage:C1525)
-			Storage:C1525.testErrors.clear()
-		End use 
-	End if 
+        This:C1470.startTime:=Milliseconds:C459
+
+        // Reset the testing context for this test
+        This:C1470.t.resetForNewTest()
+
+        // Clear any existing test errors
+        If (Storage:C1525.testErrors#Null:C1517)
+                Use (Storage:C1525)
+                        Storage:C1525.testErrors.clear()
+                End use
+        End if
+
+        // Skip test early if tagged to skip
+        If (This:C1470.shouldSkip())
+                This:C1470.skipped:=True:C214
+                This:C1470.endTime:=Milliseconds:C459
+                return
+        End if
 	
 	// Start transaction if configured to use transactions
 	var $transactionStarted : Boolean
@@ -77,22 +86,26 @@ Function run()
 		End if 
 	End if 
 	
-	This:C1470.endTime:=Milliseconds:C459
-	
+        This:C1470.endTime:=Milliseconds:C459
+
 Function getResult() : Object
-	var $duration : Integer
-	$duration:=This:C1470.endTime-This:C1470.startTime
-	
-	return New object:C1471(\
-		"name"; This:C1470.functionName; \
-		"passed"; Not:C34(This:C1470.t.failed); \
-		"failed"; This:C1470.t.failed; \
-		"duration"; $duration; \
-		"suite"; This:C1470.class.name; \
-		"runtimeErrors"; This:C1470.runtimeErrors; \
-		"logMessages"; This:C1470.t.logMessages; \
-		"tags"; This:C1470.tags\
-		)
+        var $duration : Integer
+        $duration:=This:C1470.endTime-This:C1470.startTime
+
+        return New object:C1471(\
+                "name"; This:C1470.functionName; \
+                "passed"; Not:C34(This:C1470.t.failed) && Not:C34(This:C1470.skipped); \
+                "failed"; This:C1470.t.failed; \
+                "skipped"; This:C1470.skipped; \
+                "duration"; $duration; \
+                "suite"; This:C1470.class.name; \
+                "runtimeErrors"; This:C1470.runtimeErrors; \
+                "logMessages"; This:C1470.t.logMessages; \
+                "tags"; This:C1470.tags\
+                )
+
+Function shouldSkip() : Boolean
+        return (This:C1470.tags.indexOf("skip")>=0)
 
 Function _parseTags($classCode : Text) : Collection
 	// Parse tags from function comments in source code

--- a/testing/Project/Sources/Classes/_TestRunnerTest.4dm
+++ b/testing/Project/Sources/Classes/_TestRunnerTest.4dm
@@ -321,8 +321,24 @@ Function test_error_handling_in_extracted_methods($t : cs:C1710.Testing)
 		"InvalidTest"; New object:C1471("name"; "InvalidTest"); \
 		"ValidTest"; New object:C1471("name"; "ValidTest"; "superclass"; New object:C1471("name"; "Object"))\
 		)
-	var $filteredClasses : Collection
-	$filteredClasses:=$runner._filterTestClasses($malformedStore)
-	// Should find ValidTest but skip InvalidTest (missing superclass)
-	$t.assert.areEqual($t; 1; $filteredClasses.length; "Should handle classes without superclass gracefully")
-	$t.assert.areEqual($t; "ValidTest"; $filteredClasses[0].name; "Should include ValidTest")
+        var $filteredClasses : Collection
+        $filteredClasses:=$runner._filterTestClasses($malformedStore)
+        // Should find ValidTest but skip InvalidTest (missing superclass)
+        $t.assert.areEqual($t; 1; $filteredClasses.length; "Should handle classes without superclass gracefully")
+        $t.assert.areEqual($t; "ValidTest"; $filteredClasses[0].name; "Should include ValidTest")
+
+Function test_skip_tag_counts_as_skipped($t : cs:C1710.Testing)
+
+        // Run TestRunner on a class that should be skipped
+        var $runner : cs:C1710.TestRunner
+        $runner:=cs:C1710.TestRunner.new()
+        $runner.testPatterns:=["_SkipTaggedTest*"]
+        $runner.run()
+
+        var $results : Object
+        $results:=$runner.getResults()
+
+        $t.assert.areEqual($t; 1; $results.totalTests; "Total should count skipped test")
+        $t.assert.areEqual($t; 1; $results.skipped; "Skipped test should be counted")
+        $t.assert.areEqual($t; 0; $results.failed; "Skipped test should not fail")
+        $t.assert.areEqual($t; 0; $results.passed; "Skipped test should not pass")

--- a/testing/Project/Sources/Classes/_TestSuite.4dm
+++ b/testing/Project/Sources/Classes/_TestSuite.4dm
@@ -16,16 +16,20 @@ Class constructor($class : 4D:C1709.Class; $outputFormat : Text; $testPatterns :
 	This:C1470.discoverTests()
 	
 Function run()
-	This:C1470._callSetup()
-	
-	var $testFunction : cs:C1710._TestFunction
-	For each ($testFunction; This:C1470.testFunctions)
-		This:C1470._callBeforeEach()
-		$testFunction.run()
-		This:C1470._callAfterEach()
-	End for each 
-	
-	This:C1470._callTeardown() 
+        This:C1470._callSetup()
+
+        var $testFunction : cs:C1710._TestFunction
+        For each ($testFunction; This:C1470.testFunctions)
+                If ($testFunction.shouldSkip())
+                        $testFunction.run()
+                Else
+                        This:C1470._callBeforeEach()
+                        $testFunction.run()
+                        This:C1470._callAfterEach()
+                End if
+        End for each
+
+        This:C1470._callTeardown()
 	
 Function discoverTests()
 	var $testFunctions : Collection


### PR DESCRIPTION
## Summary
- allow tests tagged with `skip` to be bypassed while tracking skipped counts
- report skipped tests in human and JSON output and adjust pass rate calculations
- document skip tag usage and add coverage for skip behavior
- avoid marking skipped tests as passed in per-test results

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aa242c03188324a597cbf7a5c55787