### PR TITLE
feat(assert): add contains assertion

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -135,6 +135,7 @@ The framework includes built-in assertion methods accessible through `$t.assert`
 - `$t.assert.isNull($t; $value; $message)` - Value must be null
 - `$t.assert.isNotNull($t; $value; $message)` - Value must not be null
 - `$t.assert.fail($t; $message)` - Force test failure
+- `$t.assert.contains($t; $container; $value; $message)` - Text or collection must contain value
 
 ### Usage Example
 ```4d

--- a/testing/Project/Sources/Classes/Assert.4dm
+++ b/testing/Project/Sources/Classes/Assert.4dm
@@ -45,12 +45,40 @@ Function isNull($t : Object; $value : Variant; $message : Text)
 	End if 
 
 Function isNotNull($t : Object; $value : Variant; $message : Text)
-	If ($value=Null)
-		If (Count parameters>=3)
-			This.fail($t; $message)
-		Else 
-			This.fail($t; "Assertion failed: value is Null")
-		End if 
-	End if 
+        If ($value=Null)
+                If (Count parameters>=3)
+                        This.fail($t; $message)
+                Else
+                        This.fail($t; "Assertion failed: value is Null")
+                End if
+        End if
+
+Function contains($t : Object; $container : Variant; $value : Variant; $message : Text)
+        var $found : Boolean
+        var $type : Integer
+        $found:=False
+        $type:=Value type:C1509($container)
+
+        Case of
+                : ($type=Is text:K8:3)
+                        $found:=(Position:C15(String:C10($value); $container)>0)
+                : ($type=Is collection:K8:32)
+                        $found:=($container.indexOf($value)#-1)
+                Else
+                        If (Count parameters>=4)
+                                This.fail($t; $message)
+                        Else
+                                This.fail($t; "Assertion failed: unsupported type for contains")
+                        End if
+                        return
+        End case
+
+        If (Not:C34($found))
+                If (Count parameters>=4)
+                        This.fail($t; $message)
+                Else
+                        This.fail($t; "Assertion failed: container does not contain value")
+                End if
+        End if
 
 

--- a/testing/Project/Sources/Classes/_AssertTest.4dm
+++ b/testing/Project/Sources/Classes/_AssertTest.4dm
@@ -157,14 +157,43 @@ Function test_message_logging($t : cs:C1710.Testing)
 	$t.assert.areEqual($t; "Custom failure message"; $mockTest.logMessages[0]; "Should log the provided message")
 
 Function test_multiple_assertions($t : cs:C1710.Testing)
-	var $mockTest : cs:C1710.Testing
-	$mockTest:=cs:C1710.Testing.new()
+        var $mockTest : cs:C1710.Testing
+        $mockTest:=cs:C1710.Testing.new()
 	
 	// Test multiple assertions accumulating messages
 	$t.assert.areEqual($mockTest; 1; 2; "First failure")
 	$t.assert.areEqual($mockTest; "a"; "b"; "Second failure")
 	
-	$t.assert.isTrue($t; $mockTest.failed; "Multiple failed assertions should mark test as failed")
-	$t.assert.areEqual($t; 2; $mockTest.logMessages.length; "Should accumulate multiple failure messages")
-	$t.assert.areEqual($t; "First failure"; $mockTest.logMessages[0]; "Should store first message")
-	$t.assert.areEqual($t; "Second failure"; $mockTest.logMessages[1]; "Should store second message")
+        $t.assert.isTrue($t; $mockTest.failed; "Multiple failed assertions should mark test as failed")
+        $t.assert.areEqual($t; 2; $mockTest.logMessages.length; "Should accumulate multiple failure messages")
+        $t.assert.areEqual($t; "First failure"; $mockTest.logMessages[0]; "Should store first message")
+        $t.assert.areEqual($t; "Second failure"; $mockTest.logMessages[1]; "Should store second message")
+
+Function test_contains_with_text($t : cs:C1710.Testing)
+        var $mockTest : cs:C1710.Testing
+        $mockTest:=cs:C1710.Testing.new()
+
+        // Successful text containment
+        $t.assert.contains($mockTest; "hello world"; "world"; "Should find substring")
+        $t.assert.isFalse($t; $mockTest.failed; "Valid substring should pass")
+
+        // Failing text containment
+        $mockTest:=cs:C1710.Testing.new()
+        $t.assert.contains($mockTest; "hello"; "world"; "Missing substring should fail")
+        $t.assert.isTrue($t; $mockTest.failed; "Missing substring should fail")
+
+Function test_contains_with_collection($t : cs:C1710.Testing)
+        var $mockTest : cs:C1710.Testing
+        $mockTest:=cs:C1710.Testing.new()
+
+        var $col : Collection
+        $col:=["a"; "b"; "c"]
+
+        // Successful collection containment
+        $t.assert.contains($mockTest; $col; "b"; "Should find element in collection")
+        $t.assert.isFalse($t; $mockTest.failed; "Existing element should pass")
+
+        // Failing collection containment
+        $mockTest:=cs:C1710.Testing.new()
+        $t.assert.contains($mockTest; $col; "d"; "Missing element should fail")
+        $t.assert.isTrue($t; $mockTest.failed; "Missing element should fail")


### PR DESCRIPTION
## Summary
- add `assert.contains` to validate substring or collection membership
- document new assertion
- cover new assertion with unit tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68aa359daad88324bd505a329da70ae8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a contains assertion to the assertion library to verify that text or collections include a given value, with clear failure messages for non-containment or unsupported types.
* Documentation
  * Updated the guide to document the new contains assertion and its usage.
* Tests
  * Added test coverage for contains across text and collection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->