### PR TITLE
Add runtime error assertion helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A comprehensive unit testing framework for the 4D platform with test tagging, fi
 - **Multiple output formats** - Human-readable and JSON output
 - **CI/CD ready** - Structured JSON output for automated testing
 - **Transaction management** - Automatic test isolation with rollback
+- **Error assertions** - Verify that code raises expected runtime errors
 
 ## Quick Example
 

--- a/testing/Project/Sources/Classes/Assert.4dm
+++ b/testing/Project/Sources/Classes/Assert.4dm
@@ -45,12 +45,63 @@ Function isNull($t : Object; $value : Variant; $message : Text)
 	End if 
 
 Function isNotNull($t : Object; $value : Variant; $message : Text)
-	If ($value=Null)
-		If (Count parameters>=3)
-			This.fail($t; $message)
-		Else 
-			This.fail($t; "Assertion failed: value is Null")
-		End if 
-	End if 
+        If ($value=Null)
+                If (Count parameters>=3)
+                        This.fail($t; $message)
+                Else
+                        This.fail($t; "Assertion failed: value is Null")
+                End if
+        End if
+
+Function throwsError($t : Object; $method : 4D:C1709.Function; $expectedCode : Integer; $message : Text)
+        // Verify that executing the method results in a runtime error
+
+        // Ensure error storage exists
+        If (Storage:C1525.testErrors=Null:C1517)
+                Use (Storage:C1525)
+                        Storage:C1525.testErrors:=New shared collection:C1527
+                End use
+        End if
+
+        var $beforeCount : Integer
+        $beforeCount:=Storage:C1525.testErrors.length
+
+        // Execute the provided method
+        $method.apply()
+
+        var $afterCount : Integer
+        $afterCount:=Storage:C1525.testErrors.length
+
+        // If no new error was recorded, the assertion fails
+        If ($afterCount<=$beforeCount)
+                If (Count parameters>=4)
+                        This.fail($t; $message)
+                Else
+                        This.fail($t; "Expected error but none was thrown")
+                End if
+                return
+        End if
+
+        // Capture the last error for verification
+        var $lastError : Object
+        $lastError:=Storage:C1525.testErrors[$afterCount-1]
+
+        // Clear captured errors to avoid affecting outer test context
+        Use (Storage:C1525)
+                Storage:C1525.testErrors.clear()
+        End use
+
+        // If an expected error code was provided, verify it
+        If (Count parameters>=3) && ($expectedCode#0)
+                If ($lastError.code#$expectedCode)
+                        var $defaultMessage : Text
+                        $defaultMessage:="Expected error code "+String:C10($expectedCode)+" but got "+String:C10($lastError.code)
+                        If (Count parameters>=4)
+                                This.fail($t; $message+": "+$defaultMessage)
+                        Else
+                                This.fail($t; $defaultMessage)
+                        End if
+                End if
+        End if
 
 

--- a/testing/Project/Sources/Classes/_AssertTest.4dm
+++ b/testing/Project/Sources/Classes/_AssertTest.4dm
@@ -1,6 +1,8 @@
 // Comprehensive tests for Assert class edge cases and functionality
 Class constructor()
-
+        
+Function _noError()
+        // Helper method that completes without errors
 Function test_assert_initialization($t : cs:C1710.Testing)
 	$t.assert.isNotNull($t; $t.assert; "Assert should initialize successfully")
 
@@ -134,7 +136,37 @@ Function test_isNotNull_edge_cases($t : cs:C1710.Testing)
 	
 	$mockTest:=cs:C1710.Testing.new()  // Reset
 	$t.assert.isNotNull($mockTest; Null:C1517; "Null should fail")
-	$t.assert.isTrue($t; $mockTest.failed; "Null should fail isNotNull")
+        $t.assert.isTrue($t; $mockTest.failed; "Null should fail isNotNull")
+
+Function test_throwsError_passes_when_error_raised($t : cs:C1710.Testing)
+        var $mockTest : cs:C1710.Testing
+        $mockTest:=cs:C1710.Testing.new()
+
+        var $fn : 4D:C1709.Function
+        $fn:=ThrowRuntimeError
+
+        $t.assert.throwsError($mockTest; $fn; 0; "Should raise an error")
+        $t.assert.isFalse($t; $mockTest.failed; "throwsError should pass for expected error")
+
+Function test_throwsError_fails_for_wrong_code($t : cs:C1710.Testing)
+        var $mockTest : cs:C1710.Testing
+        $mockTest:=cs:C1710.Testing.new()
+
+        var $fn : 4D:C1709.Function
+        $fn:=ThrowRuntimeError
+
+        $t.assert.throwsError($mockTest; $fn; -9999; "Wrong error code")
+        $t.assert.isTrue($t; $mockTest.failed; "throwsError should fail when error code differs")
+
+Function test_throwsError_fails_when_no_error($t : cs:C1710.Testing)
+        var $mockTest : cs:C1710.Testing
+        $mockTest:=cs:C1710.Testing.new()
+
+        var $fn : 4D:C1709.Function
+        $fn:=This:C1470._noError
+
+        $t.assert.throwsError($mockTest; $fn; 0; "Expected error not thrown")
+        $t.assert.isTrue($t; $mockTest.failed; "throwsError should fail when no error occurs")
 
 Function test_fail_method($t : cs:C1710.Testing)
 	var $mockTest : cs:C1710.Testing

--- a/testing/Project/Sources/Methods/ThrowRuntimeError.4dm
+++ b/testing/Project/Sources/Methods/ThrowRuntimeError.4dm
@@ -1,0 +1,5 @@
+//%attributes = {}
+// Helper method that always triggers a runtime error
+var $obj : Object
+$obj:=Null:C1517
+$obj.nonexistent:="value"  // Causes runtime error


### PR DESCRIPTION
## Summary
- extend Assert class with `throwsError` to verify runtime errors
- cover error assertions with comprehensive tests
- document new error assertion feature in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68aa359daad88324bd505a329da70ae8