### PR TITLE
Add subtest support for table-driven tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A comprehensive unit testing framework for the 4D platform with test tagging, fi
 - **Multiple output formats** - Human-readable and JSON output
 - **CI/CD ready** - Structured JSON output for automated testing
 - **Transaction management** - Automatic test isolation with rollback
+- **Subtests** - Run table-driven tests with `t.run`
 
 ## Quick Example
 
@@ -63,6 +64,21 @@ tool4d --project YourProject.4DProject --startup-method "test" --user-param "tes
 # Filter by tags
 tool4d --project YourProject.4DProject --startup-method "test" --user-param "tags=unit"
 tool4d --project YourProject.4DProject --startup-method "test" --user-param "tags=unit excludeTags=slow"
+```
+
+## Table-Driven Tests
+
+Use subtests to build table-driven tests. Each call to `t.run` executes the provided function with a fresh testing context. If a subtest fails, the parent test is marked as failed. Subtests run with the same `This` object as the parent test, so helper methods and state remain accessible.
+
+```4d
+Function test_math($t : cs.Testing)
+    var $cases : Collection
+    $cases:=[New object("name"; "1+1"; "in"; 1; "want"; 2)]
+
+    var $case : Object
+    For each ($case; $cases)
+        $t.run($case.name; Formula($1.assert.areEqual($1; $case.want; $case.in+1; "math works")))
+    End for each
 ```
 
 ## Output

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -13,6 +13,7 @@ A comprehensive unit testing framework for the 4D platform with enhanced reporti
 - [Test Filtering](#test-filtering)
 - [Test Tagging](#test-tagging)
 - [Test Lifecycle Methods](#test-lifecycle-methods)
+- [Table-Driven Tests](#table-driven-tests)
 - [Mocking and Test Utilities](#mocking-and-test-utilities)
 - [CI/CD Integration](#cicd-integration)
 - [Framework Architecture](#framework-architecture)
@@ -28,6 +29,7 @@ A comprehensive unit testing framework for the 4D platform with enhanced reporti
 - **Rich Assertions**: Built-in assertion library with helpful error messages
 - **Enhanced Reporting**: Detailed test results with execution times and pass rates
 - **JSON Output**: Structured output for CI/CD integration and automated processing
+- **Subtest Support**: Create table-driven tests using `t.run`
 - **Mock Support**: Built-in mocking utilities for isolated unit testing
 - **CI/CD Ready**: GitHub Actions integration for automated testing
 
@@ -750,6 +752,21 @@ For each test class, the framework executes lifecycle methods in this order:
 - **Use `teardown()` for final cleanup** to release resources and reset global state
 - **Keep lifecycle methods lightweight** to minimize test execution overhead
 - **Handle errors gracefully** in cleanup methods to prevent test failures from masking real issues
+
+## Table-Driven Tests
+
+Use subtests to implement table-driven tests. The `t.run` method executes a named subtest with a fresh testing context. If a subtest fails, the parent test is marked as failed and the subtest's log messages are prefixed with its name. Subtests share the same `This` object as the parent test, so any instance methods or state remain available.
+
+```4d
+Function test_math_operations($t : cs.Testing.Testing)
+    var $cases : Collection
+    $cases:=[New object("name"; "1+1"; "in"; 1; "want"; 2)]
+
+    var $case : Object
+    For each ($case; $cases)
+        $t.run($case.name; Formula($1.assert.areEqual($1; $case.want; $case.in+1; "math works")))
+    End for each
+```
 
 ## Transaction Management
 

--- a/testing/Project/Sources/Classes/Testing.4dm
+++ b/testing/Project/Sources/Classes/Testing.4dm
@@ -6,6 +6,7 @@ property logMessages : Collection
 property assert : cs:C1710.Assert
 property stats : cs:C1710.UnitStatsTracker
 property failureCallChain : Collection
+property classInstance : 4D:C1709.Object
 
 Class constructor()
 	This:C1470.failed:=False:C215
@@ -36,8 +37,50 @@ Function resetForNewTest()
 	This:C1470.stats.resetStatistics()
 	This:C1470.failureCallChain:=Null
 	
-Function run($name : Text; $subtest : 4D:C1709.Function)
-	// This will be implemented later
+Function run($name : Text; $subtest : 4D:C1709.Function) : Boolean
+        // Execute a named subtest with its own Testing context
+        // Returns true if the subtest passed
+
+        var $subT : cs:C1710.Testing
+        $subT:=cs:C1710.Testing.new()
+
+        // Share assertion and statistics objects with parent
+        $subT.assert:=This:C1470.assert
+        $subT.stats:=This:C1470.stats
+        $subT.classInstance:=This:C1470.classInstance
+
+        var $result : Boolean
+        $result:=True:C214
+
+        // Allow calling run with no subtest for compatibility
+        If ($subtest=Null:C1517)
+                return $result
+        End if
+
+        // Execute the subtest with the parent test context
+        var $context : 4D:C1709.Object
+        $context:=This:C1470.classInstance
+        If ($context=Null:C1517)
+                $context:=This:C1470
+        End if
+        $subtest.apply($context; [$subT])
+
+        // Propagate log messages with subtest name prefix
+        var $message : Text
+        For each ($message; $subT.logMessages)
+                This:C1470.log($name+": "+$message)
+        End for each
+
+        // If the subtest failed, mark parent as failed and capture call chain
+        If ($subT.failed)
+                This:C1470.fail()
+                If ($subT.failureCallChain#Null)
+                        This:C1470.failureCallChain:=$subT.failureCallChain
+                End if
+                $result:=False:C215
+        End if
+
+        return $result
 
 // Transaction management methods for manual control
 

--- a/testing/Project/Sources/Classes/_TestFunction.4dm
+++ b/testing/Project/Sources/Classes/_TestFunction.4dm
@@ -16,6 +16,7 @@ Class constructor($class : 4D:C1709.Class; $classInstance : 4D:C1709.Object; $fu
 	This:C1470.function:=$function
         This:C1470.functionName:=$name
         This:C1470.t:=cs:C1710.Testing.new()
+        This:C1470.t.classInstance:=$classInstance
         This:C1470.runtimeErrors:=[]
         This:C1470.skipped:=False:C215
         This:C1470.tags:=This:C1470._parseTags($classCode || "")

--- a/testing/Project/Sources/Classes/_TestingTest.4dm
+++ b/testing/Project/Sources/Classes/_TestingTest.4dm
@@ -113,15 +113,41 @@ Function test_log_with_special_characters($t : cs:C1710.Testing)
 	$t.assert.areEqual($t; "Message with\nnewlines"; $testing.logMessages[1]; "Should preserve newlines")
 	$t.assert.areEqual($t; "Message with\ttabs"; $testing.logMessages[2]; "Should preserve tabs")
 
-Function test_run_method_placeholder($t : cs:C1710.Testing)
-	
-	var $testing : cs:C1710.Testing
-	$testing:=cs:C1710.Testing.new()
-	
-	// Test that run method exists (even if not implemented)
-	// This is a placeholder method in the current implementation
-	$t.assert.isNotNull($t; $testing.run; "Run method should exist")
-	
-	// Call it to ensure it doesn't crash
-	$testing.run("test"; Null:C1517)
-	// Should not throw an error
+Function test_run_executes_subtest($t : cs:C1710.Testing)
+
+        var $testing : cs:C1710.Testing
+        $testing:=cs:C1710.Testing.new()
+
+        var $result : Boolean
+        $result:=$testing.run("sub"; Formula($1.log("ran")))
+
+        $t.assert.isTrue($t; $result; "Run should return true when subtest passes")
+        $t.assert.areEqual($t; 1; $testing.logMessages.length; "Parent should capture subtest log")
+        $t.assert.areEqual($t; "sub: ran"; $testing.logMessages[0]; "Log should be prefixed with subtest name")
+
+Function test_run_propagates_failure($t : cs:C1710.Testing)
+
+        var $testing : cs:C1710.Testing
+        $testing:=cs:C1710.Testing.new()
+
+        var $result : Boolean
+        $result:=$testing.run("fail"; Formula($1.fail()))
+
+        $t.assert.isFalse($t; $result; "Run should return false when subtest fails")
+        $t.assert.isTrue($t; $testing.failed; "Parent test should be marked as failed")
+
+
+Function test_run_uses_parent_context($t : cs:C1710.Testing)
+
+        // Verify that subtests execute with the same object context as the parent
+        This.contextValue:="parent"
+
+        $t.run("ctx"; This._setContextChild)
+
+        $t.assert.areEqual($t; "child"; This.contextValue; "Subtest should run with parent This context")
+
+Function _setContextChild($t : cs:C1710.Testing)
+
+        $t.log("running")
+        This.contextValue:="child"
+


### PR DESCRIPTION
## Summary
- add `t.run` to Testing for executing named subtests
- document subtest usage for table-driven tests
- cover subtest execution, context preservation, and failure propagation with tests

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c189e04290832498cc597de2a3b1ed