### PR TITLE
Prevent stats carryover between subtests

### DIFF
--- a/testing/Project/Sources/Classes/Testing.4dm
+++ b/testing/Project/Sources/Classes/Testing.4dm
@@ -44,10 +44,9 @@ Function run($name : Text; $subtest : 4D:C1709.Function; $data : Variant) : Bool
         var $subT : cs:C1710.Testing
         $subT:=cs:C1710.Testing.new()
 
-        // Share assertion and statistics objects with parent
-        $subT.assert:=This:C1470.assert
-        $subT.stats:=This:C1470.stats
-        $subT.classInstance:=This:C1470.classInstance
+       // Share assertion object with parent but keep stats isolated
+       $subT.assert:=This:C1470.assert
+       $subT.classInstance:=This:C1470.classInstance
 
         var $result : Boolean
         $result:=True:C214

--- a/testing/Project/Sources/Classes/_TestingTest.4dm
+++ b/testing/Project/Sources/Classes/_TestingTest.4dm
@@ -172,6 +172,22 @@ Function test_run_with_data_argument($t : cs:C1710.Testing)
         $t.assert.areEqual($t; "bad: 3"; $testing.logMessages[1]; "Should prefix log with case name")
         $t.assert.isTrue($t; $testing.failed; "Parent should fail if any case fails")
 
+Function test_run_subtest_stats_isolated($t : cs:C1710.Testing)
+
+        var $testing : cs:C1710.Testing
+        $testing:=cs:C1710.Testing.new()
+
+        // First subtest records a stat
+        $testing.run("first"; Formula($1.stats.mock("mocked"; []; Null)))
+
+        // Second subtest should start with fresh stats
+        $testing.run("second"; Formula($1.assert.areEqual($1; 0; $1.stats.getStat("mocked").getNumberOfCalls(); "Stats should not carry over between subtests")))
+
+        // Parent stats should remain unaffected
+        var $parentStat : cs:C1710._UnitStatsDetail
+        $parentStat:=$testing.stats.getStat("mocked")
+        $t.assert.areEqual($t; 0; $parentStat.getNumberOfCalls(); "Parent stats should remain unaffected")
+
 Function _addOneCase($t : cs:C1710.Testing; $case : Object)
 
         var $got : Integer


### PR DESCRIPTION
## Summary
- avoid sharing UnitStatsTracker between parent tests and subtests so stats don't leak across subtests
- add regression test ensuring each subtest starts with a fresh stats tracker

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c2f1f6cff88324863d1f927d1a260b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Subtest statistics are now isolated; metrics recorded in one subtest no longer appear in sibling subtests.
  - Parent test statistics remain unaffected by subtest activity.

- Bug Fixes
  - Eliminated unintended sharing of statistics between parent and subtests, preventing cross-test leakage.

- Tests
  - Added test coverage validating that each subtest maintains its own statistics and that the parent’s statistics do not change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->