### PR TITLE
Stabilize worker error handler lifecycle

### DIFF
--- a/testing/Project/Sources/Classes/Testing.4dm
+++ b/testing/Project/Sources/Classes/Testing.4dm
@@ -144,19 +144,7 @@ Function withTransaction($operation : 4D:C1709.Function) : Boolean
 	
 	START TRANSACTION:C239
 	
-	// Set up error handler to catch any errors during operation
-	var $previousErrorHandler : Text
-	$previousErrorHandler:=Method called on error:C704
-	ON ERR CALL:C155("TestErrorHandler")
-	
-	$operation.apply()
-	
-	// Restore previous error handler
-	If ($previousErrorHandler#"")
-		ON ERR CALL:C155($previousErrorHandler)
-	Else 
-		ON ERR CALL:C155("")
-	End if 
+        $operation.apply()
 	
 	// Check if operation succeeded (no test failures)
 	If (Not:C34(This:C1470.failed))
@@ -177,19 +165,7 @@ Function withTransactionValidate($operation : 4D:C1709.Function) : Boolean
 	
 	START TRANSACTION:C239
 	
-	// Set up error handler to catch any errors during operation
-	var $previousErrorHandler : Text
-	$previousErrorHandler:=Method called on error:C704
-	ON ERR CALL:C155("TestErrorHandler")
-	
-	$operation.apply()
-	
-	// Restore previous error handler
-	If ($previousErrorHandler#"")
-		ON ERR CALL:C155($previousErrorHandler)
-	Else 
-		ON ERR CALL:C155("")
-	End if 
+        $operation.apply()
 	
 	// Validate transaction if test succeeded
 	If (Not:C34(This:C1470.failed))

--- a/testing/Project/Sources/Classes/_TestFunction.4dm
+++ b/testing/Project/Sources/Classes/_TestFunction.4dm
@@ -50,19 +50,7 @@ Function run()
 		$transactionStarted:=True
 	End if 
 	
-	// Set up error handler to capture runtime errors
-	var $previousErrorHandler : Text
-	$previousErrorHandler:=Method called on error:C704
-	ON ERR CALL:C155("TestErrorHandler")
-	
-	This:C1470.function.apply(This:C1470.classInstance; [This:C1470.t])
-	
-	// Restore previous error handler
-	If ($previousErrorHandler#"")
-		ON ERR CALL:C155($previousErrorHandler)
-	Else 
-		ON ERR CALL:C155("")
-	End if 
+        This:C1470.function.apply(This:C1470.classInstance; [This:C1470.t])
 	
 	// Capture any runtime errors that occurred
 	If (Storage:C1525.testErrors#Null:C1517) && (Storage:C1525.testErrors.length>0)


### PR DESCRIPTION
## Summary
- persist each parallel worker's error handler state so the TestErrorHandler is installed only once and the previous handler is recorded
- restore the original handler when stopping workers and clear the shared per-worker handler map to avoid lingering state between runs

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68cebc596c4883249703c7d05f539444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More reliable parallel test execution with automatic sequential fallback when needed.
  - Consolidated reporting and timing for clearer run summaries.

- Bug Fixes
  - Prevented error handler leakage across workers.
  - Runtime errors now consistently mark tests as failed.
  - Ensured proper cleanup after parallel runs.

- Refactor
  - Reorganized runner flow into clear prepare/execute steps.
  - Simplified transaction helpers by removing embedded error handler wrappers.
  - Improved result aggregation across workers for parallel runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->