### PR TITLE
Disable triggers by default and add trigger helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A comprehensive unit testing framework for the 4D platform with test tagging, fi
 - **Multiple output formats** - Human-readable and JSON output
 - **CI/CD ready** - Structured JSON output for automated testing
 - **Transaction management** - Automatic test isolation with rollback
+- **Trigger control** - Database triggers disabled by default with opt-in helpers
 - **Subtests** - Run table-driven tests with `t.run`
 
 ## Quick Example

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -805,6 +805,32 @@ Function _checkMathCase($t : cs.Testing.Testing; $case : Object)
     $t.assert.areEqual($t; $case.want; $case.in+1; "math works")
 ```
 
+## Trigger Management
+
+Database triggers are disabled for every test context by default. The framework issues `ALTER DATABASE DISABLE TRIGGERS` whenever a `Testing` instance is created or reset so tests begin from a consistent state without trigger side effects. Any table-level trigger overrides are tracked and reverted automatically before the next test runs.
+
+Use the following helpers on the `$t` context when a test needs trigger support:
+
+- `$t.disableAllTriggers()` – Explicitly disable triggers for the current session and clear any table overrides
+- `$t.enableAllTriggers()` – Re-enable triggers for all tables in the current session
+- `$t.enableTableTriggers(tableName)` – Enable triggers for a single table while keeping others disabled
+- `$t.disableTableTriggers(tableName)` – Disable triggers for a specific table and remove it from the override list
+- `$t.restoreTriggerDefaults()` – Convenience wrapper that restores the default “all triggers disabled” state
+
+Table names are quoted automatically, so you can enable triggers on tables with spaces or special characters without additional escaping. Any double quotes inside the name are doubled per SQL rules.
+
+```4d
+Function test_trigger_callbacks($t : cs.Testing.Testing)
+    // Enable triggers only for the tables needed by this scenario
+    $t.enableTableTriggers("AuditLog")
+
+    // Execute behavior that relies on table triggers
+    This._performOperation()
+
+    // Return to the default trigger state for the remainder of the test
+    $t.restoreTriggerDefaults()
+```
+
 ## Transaction Management
 
 The framework provides automatic transaction management for test isolation and manual transaction control for advanced scenarios.

--- a/testing/Project/Sources/Classes/_TestingTriggerMock.4dm
+++ b/testing/Project/Sources/Classes/_TestingTriggerMock.4dm
@@ -1,0 +1,17 @@
+Class extends Testing
+
+property executedStatements : Collection
+
+Class constructor()
+        Super:C1705()
+
+        If (This:C1470.executedStatements=Null:C1517)
+                This:C1470.executedStatements:=[]
+        End if
+
+Function _performSQLExecution($statement : Text)
+        If (This:C1470.executedStatements=Null:C1517)
+                This:C1470.executedStatements:=[]
+        End if
+
+        This:C1470.executedStatements.push($statement)


### PR DESCRIPTION
## Summary
- disable triggers whenever a `Testing` context is created or reset and add helper methods to control trigger state
- add a mock testing context and unit tests that verify the new trigger-management API
- document trigger management helpers and call out the feature in the README

## Testing
- not run (tool4d runtime is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68d14fef1e9083249bc6580a81fa7c45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added trigger control: database triggers are disabled by default in tests with opt-in helpers to enable/disable globally or per table and restore defaults. Automatic tracking and reversion ensure clean test isolation.

- Documentation
  - Updated README key features to include trigger control.
  - Added a “Trigger Management” guide with behavior details, usage examples, and notes on table naming.

- Tests
  - Added comprehensive tests covering default state, global/per-table enable/disable, restoration, and test reset behavior, plus a lightweight mock for verifying executed statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->