### PR TITLE
Fix: Propagate assertions from subtests to parent test context

### DIFF
--- a/testing/Project/Sources/Classes/Testing.4dm
+++ b/testing/Project/Sources/Classes/Testing.4dm
@@ -105,6 +105,12 @@ Function run($name : Text; $subtest : 4D:C1709.Function; $data : Variant) : Bool
                 This:C1470.log($name+": "+$message)
         End for each
 
+        // Propagate assertions from subtest to parent
+        var $assertion : Object
+        For each ($assertion; $subT.assertions)
+                This:C1470.assertions.push($assertion)
+        End for each
+
         // If the subtest failed, mark parent as failed and capture call chain
         If ($subT.failed)
                 This:C1470.fail()

--- a/testing/Project/Sources/Classes/_TestingTest.4dm
+++ b/testing/Project/Sources/Classes/_TestingTest.4dm
@@ -188,6 +188,34 @@ Function test_run_subtest_stats_isolated($t : cs:C1710.Testing)
         $parentStat:=$testing.stats.getStat("mocked")
         $t.assert.areEqual($t; 0; $parentStat.getNumberOfCalls(); "Parent stats should remain unaffected")
 
+Function test_run_propagates_assertions($t : cs:C1710.Testing)
+
+        var $testing : cs:C1710.Testing
+        $testing:=cs:C1710.Testing.new()
+
+        var $cases : Collection
+        $cases:=[\
+                New object("name"; "case1"; "value"; 1);\
+                New object("name"; "case2"; "value"; 2);\
+                New object("name"; "case3"; "value"; 3)\
+        ]
+
+        var $case : Object
+        For each ($case; $cases)
+                $testing.run($case.name; This._assertionSubtest; $case)
+        End for each
+
+        // Each subtest makes 1 assertion, so we should have 3 assertions total
+        $t.assert.areEqual($t; 3; $testing.assertions.length; "Parent should capture all subtest assertions")
+
+        // Verify parent did not fail (all assertions passed)
+        $t.assert.isFalse($t; $testing.failed; "Parent should not fail when subtests pass")
+
+Function _assertionSubtest($t : cs:C1710.Testing; $case : Object)
+
+        // Make one assertion per subtest
+        $t.assert.isTrue($t; $case.value>0; "Value should be positive")
+
 Function _addOneCase($t : cs:C1710.Testing; $case : Object)
 
         var $got : Integer

--- a/testing/Resources/en.lproj/syntaxEN.json
+++ b/testing/Resources/en.lproj/syntaxEN.json
@@ -651,13 +651,13 @@
 			],
 			"Summary": ""
 		},
-		"run()": {
-			"Syntax": "**.run**()",
+		"discoverTests()": {
+			"Syntax": "**.discoverTests**()",
 			"Params": [],
 			"Summary": ""
 		},
-		"discoverTests()": {
-			"Syntax": "**.discoverTests**()",
+		"run()": {
+			"Syntax": "**.run**()",
 			"Params": [],
 			"Summary": ""
 		},
@@ -1042,11 +1042,6 @@
 		}
 	},
 	"ParallelTestRunner": {
-		"run()": {
-			"Syntax": "**.run**()",
-			"Params": [],
-			"Summary": ""
-		},
 		"completedSuites": {
 			"Syntax": "completedSuites : Integer"
 		},
@@ -1424,21 +1419,40 @@
 			"Summary": ""
 		},
 		"fail()": {
-			"Syntax": "**.fail**()",
-			"Params": [],
+			"Syntax": "**.fail**( *expected* : Variant; *actual* : Variant; *message* : Text )",
+			"Params": [
+				[
+					"expected",
+					"Variant",
+					"->"
+				],
+				[
+					"actual",
+					"Variant",
+					"->"
+				],
+				[
+					"message",
+					"Text",
+					"->"
+				]
+			],
 			"Summary": ""
-		},
-		"classInstance": {
-			"Syntax": "classInstance : 4D.Object"
-		},
-		"assert": {
-			"Syntax": "assert : cs.Testing.Assert"
 		},
 		"failureCallChain": {
 			"Syntax": "failureCallChain : Collection"
 		},
 		"stats": {
 			"Syntax": "stats : cs.Testing.UnitStatsTracker"
+		},
+		"assert": {
+			"Syntax": "assert : cs.Testing.Assert"
+		},
+		"classInstance": {
+			"Syntax": "classInstance : 4D.Object"
+		},
+		"assertions": {
+			"Syntax": "assertions : Collection"
 		},
 		"logMessages": {
 			"Syntax": "logMessages : Collection"
@@ -2022,7 +2036,7 @@
 			"Summary": ""
 		},
 		"fail()": {
-			"Syntax": "**.fail**( *t* : Object; *message* : Text )",
+			"Syntax": "**.fail**( *t* : Object; *message* : Text; *expected* : Variant; *actual* : Variant )",
 			"Params": [
 				[
 					"t",
@@ -2032,6 +2046,16 @@
 				[
 					"message",
 					"Text",
+					"->"
+				],
+				[
+					"expected",
+					"Variant",
+					"->"
+				],
+				[
+					"actual",
+					"Variant",
 					"->"
 				]
 			],
@@ -2139,8 +2163,8 @@
 			],
 			"Summary": ""
 		},
-		"test_error_information_structure()": {
-			"Syntax": "**.test_error_information_structure**( *t* : cs.Testing.Testing )",
+		"test_testing_context_properties()": {
+			"Syntax": "**.test_testing_context_properties**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -2150,8 +2174,30 @@
 			],
 			"Summary": ""
 		},
-		"test_testing_context_properties()": {
-			"Syntax": "**.test_testing_context_properties**( *t* : cs.Testing.Testing )",
+		"test_local_errors_remain_in_storage()": {
+			"Syntax": "**.test_local_errors_remain_in_storage**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_global_error_collection()": {
+			"Syntax": "**.test_global_error_collection**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_error_information_structure()": {
+			"Syntax": "**.test_error_information_structure**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",


### PR DESCRIPTION
## Summary
- Fixed assertion propagation in `$t.run()` subtests
- Assertions made within subtests are now included in test output and counts
- Added test coverage for assertion propagation

## Problem
Assertions made within `$t.run()` sub-tests were not being included in test output or assertion counts. Only log messages and failure status were propagated to the parent test context.

## Solution
Added assertion propagation loop in `Testing.run()` to copy sub-test assertions to parent context, matching existing log message propagation behavior.

## Changes
- `Testing.4dm`: Added loop at lines 108-112 to propagate subtest assertions to parent
- `_TestingTest.4dm`: Added `test_run_propagates_assertions()` test to verify fix works correctly

## Test Plan
- [x] All existing tests pass (152 tests, 151 passed, 1 skipped)
- [x] New test `test_run_propagates_assertions()` verifies assertions are propagated
- [x] Verified fix resolves original issue with table-driven tests

## Impact
Test reports now accurately reflect all assertions made, including those in table-driven test cases using `$t.run()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Subtest assertions now propagate to the parent test, improving aggregated results.
  - Enhanced failure reporting: fail() accepts expected and actual values.
  - TestRunner exposes assertion helpers and an assertions collection; run/discoverTests entries updated.

- Documentation
  - Public API reference updated to reflect TestRunner changes and the removal of ParallelTestRunner’s run entry.

- Tests
  - Added tests verifying assertion propagation from subtests and that parent tests remain passing when all subtests succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->