### PR TITLE
Fix: Don't create spurious assertion when subtest fails

### DIFF
--- a/testing/Project/Sources/Classes/Testing.4dm
+++ b/testing/Project/Sources/Classes/Testing.4dm
@@ -113,7 +113,7 @@ Function run($name : Text; $subtest : 4D:C1709.Function; $data : Variant) : Bool
 
         // If the subtest failed, mark parent as failed and capture call chain
         If ($subT.failed)
-                This:C1470.fail()
+                This:C1470.failed:=True:C214
                 If ($subT.failureCallChain#Null)
                         This:C1470.failureCallChain:=$subT.failureCallChain
                 End if


### PR DESCRIPTION
When a subtest failed, Testing.run() called This.fail() which created an extra assertion record with null/empty values. Since the subtest's assertions are already propagated, we should just set the failed flag directly without creating another assertion.

Changes:
- Testing.4dm line 116: Changed This.fail() to This.failed:=True

🤖 Generated with [Claude Code](https://claude.com/claude-code)