### PR TITLE
Remove unreliable line numbers from assertion records

### DIFF
--- a/testing/Project/Sources/Classes/Assert.4dm
+++ b/testing/Project/Sources/Classes/Assert.4dm
@@ -105,43 +105,31 @@ Function contains($t : Object; $container : Variant; $value : Variant; $message 
 	End if 
 	
 Function _recordAssertion($t : Object; $passed : Boolean; $expected : Variant; $actual : Variant; $message : Text; $callChain : Collection)
-	var $cc : Collection
-	var $line : Variant
-	
-	// Use provided call chain if available, otherwise capture it
-	If (Count parameters>=6) && ($callChain#Null)
-		$cc:=$callChain
-	Else 
-		$cc:=Get call chain:C1662
-	End if 
-	
-	$line:=Null:C1517
-	If ($cc.length>2) && ($cc[2].line#Null:C1517)
-		$line:=$cc[2].line
-	End if 
+	// Note: Line numbers from 4D's call chain are not reliable for showing source line locations
+	// They reference internal function offsets rather than actual source lines
+	// Therefore, we omit line numbers from assertion records
+
 	var $assertInfo : Object
 	$assertInfo:=New object:C1471(\
 		"passed"; $passed; \
 		"expected"; This:C1470._sanitizeValue($expected); \
 		"actual"; This:C1470._sanitizeValue($actual); \
-		"message"; $message; \
-		"line"; $line\
+		"message"; $message\
 		)
 	$t.assertions.push($assertInfo)
-	
+
 Function _sanitizeValue($value : Variant) : Variant
 	var $type : Integer
 	$type:=Value type:C1509($value)
-	
+
 	// Use placeholders for complex structures to avoid serialization errors
-	Case of 
+	Case of
 		: ($type=Is object:K8:27)
 			return "<object>"
 		: ($type=Is collection:K8:32)
 			return "<collection>"
-		Else 
+		Else
 			return $value
-	End case 
-	
-	
-	
+	End case
+
+

--- a/testing/Resources/en.lproj/syntaxEN.json
+++ b/testing/Resources/en.lproj/syntaxEN.json
@@ -903,6 +903,17 @@
 			],
 			"Summary": ""
 		},
+		"test_run_propagates_assertions()": {
+			"Syntax": "**.test_run_propagates_assertions**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
 		"test_fatal_method()": {
 			"Syntax": "**.test_fatal_method**( *t* : cs.Testing.Testing )",
 			"Params": [


### PR DESCRIPTION
4D's Get call chain provides line numbers that reference internal function offsets rather than actual source file line numbers. This causes all assertions to report incorrect line numbers (typically showing the same line number for all assertions in a test).

Since reliable source line numbers cannot be obtained from the call chain, this commit removes the line number field from assertion records entirely.

Impact: Assertion records no longer include a "line" field. The failure messages and call chains still provide sufficient context for debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)