### PR TITLE
feat: resilient error reporting across component/host boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,18 @@ testing/Libraries/lib4d-arm64.dylib
 example_Build/*
 testing_Build/*
 actions-runner/*
+Makefile.local
+
+# Local OS / IDE
+.DS_Store
+
+# tool4d-installed components (local dev)
+Components/
+
+# Test run output
+testing/Logs/
+testing/test-results/
+
+# Local 4D data (tool4d / runner)
+testing/*.4DD
+testing/*.Match

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,11 @@ This project provides a complete testing framework for 4D applications featuring
 - **Auto test discovery** - Finds test classes ending with "Test"  
 - **Comment-based tagging** - Organize tests with `// #tags: unit, integration, slow`
 - **Flexible filtering** - Run specific test subsets by name, pattern, or tags
-- **Multiple output formats** - Human-readable and JSON output with terse/verbose modes
-- **CI/CD ready** - Structured JSON output for automated testing pipelines
+- **Multiple output formats** - Human-readable, JSON, and JUnit XML with terse/verbose modes
+- **CI/CD ready** - Structured JSON / JUnit XML output for automated testing pipelines
+- **File output** - Write JSON or JUnit reports directly to disk via `outputPath=`
+- **Runtime error capture** - Per-test and global capture of host runtime errors with stack chains
+- **Host project integration** - Captures errors raised in host code when used as a component
 - **Parallel test execution** - Run test suites concurrently for improved performance
 - **Automatic transaction management** - Test isolation with automatic rollback
 - **Manual transaction control** - Full transaction lifecycle management for advanced scenarios
@@ -98,6 +101,12 @@ If you need more control or the Makefile doesn't meet your needs:
 --user-param "format=junit tags=unit"
 --user-param "format=junit outputPath=results/junit.xml"
 
+# JSON / JUnit file output (clean, sidesteps any debug noise on stdout)
+--user-param "format=json outputPath=test-results/report.json"
+
+# Include callChain on failed tests in terse JSON without going full verbose
+--user-param "format=json callchain=true"
+
 # Parallel execution
 --user-param "parallel=true"
 --user-param "parallel=true maxWorkers=4"
@@ -183,13 +192,28 @@ The generated XML includes:
 Example output structure:
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="4D Test Results" tests="121" failures="0" errors="0" time="1.234">
-  <testsuite name="_ExampleTest" tests="5" failures="0" errors="0" time="0.156">
+<testsuites name="4D Test Results" tests="121" failures="0" errors="0" skipped="1"
+            time="1.234" timestamp="2026-05-04T16:47:10">
+  <testsuite name="_ExampleTest" tests="5" failures="0" errors="0" skipped="0" time="0.156">
     <testcase classname="_ExampleTest" name="test_areEqual_pass" 
               file="testing/Project/Sources/Classes/_ExampleTest.4dm" time="0.023"/>
+    <testcase classname="_ExampleTest" name="test_skipped_example"
+              file="testing/Project/Sources/Classes/_ExampleTest.4dm" time="0.000">
+      <skipped/>
+    </testcase>
   </testsuite>
+  <system-err><![CDATA[
+External runtime errors detected: 0
+]]></system-err>
 </testsuites>
 ```
+
+**Counting rules** (the framework computes these precisely):
+
+- `failures` = test methods that ended with a failed assertion.
+- `errors` = test methods that hit an `ON ERR CALL` runtime error during execution.
+- External (non-test) runtime errors are reported in `<system-err>`, not folded into `errors` — including them would inflate `errors` and drive `failures` negative when most tests pass.
+- `skipped` is set on `<testsuites>`, on each `<testsuite>`, and emitted as a `<skipped/>` child of the relevant `<testcase>` so JUnit consumers (Jenkins, JUnitXML, GitLab) classify them correctly instead of treating them as passes.
 
 ## Parallel Test Execution
 
@@ -317,3 +341,68 @@ Function test_transactionWrapper($t : cs:C1710.Testing)
 | ------------------------ | ---------------------------------------- |
 | `// #transaction: false` | Disables automatic transactions          |
 | No comment               | Enables automatic transactions (default) |
+
+## Runtime Error Capture
+
+The framework installs an `ON ERR CALL` handler around every test plus a global
+handler for non-test processes, so any 4D runtime error during a test run is
+captured and reported.
+
+### Where captured errors show up
+
+- **Per-test errors** (raised in the test's process during the test method):
+  - `runtimeErrors[]` on the test's entry in JSON output (terse and verbose)
+  - A synthetic failed assertion with `isRuntimeError: true` in the test's `assertions[]`
+  - Marks the test failed and populates `failureCallChain`
+  - JUnit `<failure>` content
+- **Global / external errors** (raised outside any test process — workers, lazy initializers, teardown):
+  - `globalErrors[]` and `globalErrorCount` on the top-level JSON report
+  - "External runtime errors detected" block in human output
+  - JUnit `<system-err>` block — intentionally **not** counted in `<testsuites>/@errors`
+
+### Captured record schema
+
+| Field | Description |
+| --- | --- |
+| `code` | 4D error code (e.g. `54`, `-10701`) |
+| `text` | Source line / `Error method` |
+| `method` | Method or formula name (`Error formula`) |
+| `line` | Line number (`Error line`) |
+| `message` | Human-readable description (`Last errors[0].message`) |
+| `processNumber` | Process where the error fired |
+| `context` | `"local"` or `"global"` |
+| `isLocal` | True for per-test capture, false for global |
+| `callChainJSON` | JSON-serialized `Get call chain` snapshot |
+
+### Host project integration (when loaded as a component)
+
+A component's own `ON ERR CALL` cannot reach errors raised in host code. To
+capture those, the host installs its own handlers and shares
+`Storage.testErrors` (a `New shared collection`) with the component:
+
+```4d
+// RunTests.4dm  (host project)
+Use (Storage)
+    If (Storage.testErrors=Null)
+        Storage.testErrors:=New shared collection
+    Else
+        Storage.testErrors.clear()
+    End if
+End use
+
+ON ERR CALL("TestErrorHandler")
+ON ERR CALL("TestGlobalErrorHandler"; 1)
+
+Testing_RunTestsWithCs(cs; Storage; $userParams)
+```
+
+The component receives `Storage` as `$hostStorage` and drains its `testErrors`
+collection both per-process (matched by `processNumber`) and globally. The host
+must define `TestErrorHandler` and `TestGlobalErrorHandler` project methods that
+push records of the schema above onto `Storage.testErrors`.
+
+If your tests hit preemptive workers and you see
+`Cannot call error handling project method <Name>`, the handler's transitive
+call graph contains methods that are not `preemptive: capable`. Mark them
+`//%attributes = {"preemptive":"capable"}` to satisfy 4D's preemptive scope
+check.

--- a/AI_AGENT_TESTING_GUIDE.md
+++ b/AI_AGENT_TESTING_GUIDE.md
@@ -259,44 +259,87 @@ tool4d --project path/to/project.4DProject --startup-method "test" --user-param 
 // #parallel: false
 ```
 
+### File Output and Call Chains
+```bash
+# Write JSON / JUnit to a file (clean, sidesteps stdout debug noise)
+--user-param "format=json outputPath=test-results/report.json"
+--user-param "format=junit outputPath=test-results/junit.xml"
+
+# Add callChain to terse-JSON failures without going full verbose
+--user-param "format=json callchain=true"
+```
+
 ## Output Formats
 
 ### Human Format (Default)
 - Real-time progress with ✓/✗ indicators
 - Individual test timing
-- Detailed error messages with call stacks
 - Summary with pass rates and totals
+- Call stacks on failure shown only when `verbose=true`
 
 ### JSON Terse (Default JSON)
 ```json
 {
   "tests": 121,
-  "passed": 121, 
+  "passed": 121,
   "failed": 0,
+  "skipped": 0,
   "rate": 100.0,
   "duration": 1234,
-  "status": "ok"
+  "status": "ok",
+  "globalErrorCount": 0,
+  "globalErrors": [],
+  "testResults": [ /* per-test entries with assertions[] and runtimeErrors[] */ ],
+  "failures": [ /* one entry per failed test; .callChain present when verbose=true or callchain=true */ ]
 }
 ```
 
 ### JSON Verbose
-```json
-{
-  "totalTests": 121,
-  "passed": 121,
-  "failed": 0,
-  "suites": [...],
-  "failedTests": [...],
-  "passRate": 100.0,
-  "status": "success"
-}
-```
+Verbose mode emits the full internal `results` structure, plus `passRate` and
+`status: "success" | "failure"`. Call chains and per-assertion details are
+always included.
 
 ### JUnit XML
-Compatible with GitLab CI/CD, Jenkins, and other CI systems:
+Compatible with GitLab CI/CD, Jenkins, and other CI systems. The framework
+emits accurate `tests`/`failures`/`errors`/`skipped` attributes on
+`<testsuites>` and each `<testsuite>`, a `<skipped/>` child element on each
+skipped `<testcase>`, and a `<system-err>` block listing external runtime
+errors that aren't tied to a specific test:
+
 ```bash
 --user-param "format=junit outputPath=custom/path/results.xml"
 ```
+
+### File Output (`outputPath`)
+Both `format=json` and `format=junit` honor `outputPath=path/to/file`. Relative
+paths resolve against the database folder; absolute POSIX (`/...`) and Windows
+(`C:...`) paths are accepted. Writing to a file sidesteps any debug noise that
+may be on stdout — recommended whenever the output is being parsed.
+
+### Including Call Chains in Terse JSON
+By default, terse JSON keeps call chains out of `failures[]` entries to stay
+small. Pass `callchain=true` (or `verbose=true`) to attach the captured stack
+chain to every failed test:
+
+```bash
+--user-param "format=json callchain=true"
+```
+
+## Runtime Error Capture
+
+The framework installs an `ON ERR CALL` handler around each test, plus a global
+handler for non-test processes. Captured errors are reported per-test (in
+`runtimeErrors[]` and as synthetic failed assertions with `isRuntimeError: true`)
+or as `globalErrors[]` / `<system-err>` for errors raised outside any test
+process. Each record carries `code`, `text`, `method`, `line`, `message`,
+`processNumber`, `context`, `isLocal`, and `callChainJSON`.
+
+When the framework is loaded as a component, the host can define its own
+`TestErrorHandler` / `TestGlobalErrorHandler` methods and share
+`Storage.testErrors` to capture errors raised in host code (which a component's
+`ON ERR CALL` cannot reach). Pass the host's `Storage` as the second argument
+to `Testing_RunTestsWithCs` to wire it up. See `docs/guide.md` for the full
+host-side wiring example.
 
 ## Best Practices
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,11 @@ This project provides a complete testing framework for 4D applications featuring
 - **Auto test discovery** - Finds test classes ending with "Test"
 - **Comment-based tagging** - Organize tests with `// #tags: unit, integration, slow`
 - **Flexible filtering** - Run specific test subsets by name, pattern, or tags
-- **Multiple output formats** - Human-readable and JSON output with terse/verbose modes
-- **CI/CD ready** - Structured JSON output for automated testing pipelines
+- **Multiple output formats** - Human-readable, JSON, and JUnit XML with terse/verbose modes
+- **CI/CD ready** - Structured JSON / JUnit XML output for automated testing pipelines
+- **File output** - Write JSON or JUnit reports directly to disk via `outputPath=`
+- **Runtime error capture** - Per-test and global capture of host runtime errors with stack chains
+- **Host project integration** - Captures errors raised in host code when used as a component
 - **Parallel test execution** - Run test suites concurrently for improved performance
 - **Automatic transaction management** - Test isolation with automatic rollback
 - **Manual transaction control** - Full transaction lifecycle management for advanced scenarios
@@ -91,6 +94,12 @@ If you need more control or the Makefile doesn't meet your needs:
 --user-param "format=json tags=integration"
 --user-param "format=junit tags=unit"
 --user-param "format=junit outputPath=results/junit.xml"
+
+# JSON / JUnit file output (clean, sidesteps any debug noise on stdout)
+--user-param "format=json outputPath=test-results/report.json"
+
+# Include callChain on failed tests in terse JSON without going full verbose
+--user-param "format=json callchain=true"
 
 # Parallel execution
 --user-param "parallel=true"
@@ -182,13 +191,28 @@ The generated XML includes:
 Example output structure:
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="4D Test Results" tests="121" failures="0" errors="0" time="1.234">
-  <testsuite name="_ExampleTest" tests="5" failures="0" errors="0" time="0.156">
+<testsuites name="4D Test Results" tests="121" failures="0" errors="0" skipped="1"
+            time="1.234" timestamp="2026-05-04T16:47:10">
+  <testsuite name="_ExampleTest" tests="5" failures="0" errors="0" skipped="0" time="0.156">
     <testcase classname="_ExampleTest" name="test_areEqual_pass" 
               file="testing/Project/Sources/Classes/_ExampleTest.4dm" time="0.023"/>
+    <testcase classname="_ExampleTest" name="test_skipped_example"
+              file="testing/Project/Sources/Classes/_ExampleTest.4dm" time="0.000">
+      <skipped/>
+    </testcase>
   </testsuite>
+  <system-err><![CDATA[
+External runtime errors detected: 0
+]]></system-err>
 </testsuites>
 ```
+
+**Counting rules** (the framework computes these precisely):
+
+- `failures` = test methods that ended with a failed assertion.
+- `errors` = test methods that hit an `ON ERR CALL` runtime error during execution.
+- External (non-test) runtime errors are reported in `<system-err>`, not folded into `errors` — including them would inflate `errors` and drive `failures` negative when most tests pass.
+- `skipped` is set on `<testsuites>`, on each `<testsuite>`, and emitted as a `<skipped/>` child of the relevant `<testcase>` so JUnit consumers (Jenkins, JUnitXML, GitLab) classify them correctly instead of treating them as passes.
 
 ## Parallel Test Execution
 
@@ -316,6 +340,71 @@ Function test_transactionWrapper($t : cs:C1710.Testing)
 | ------------------------ | ---------------------------------------- |
 | `// #transaction: false` | Disables automatic transactions          |
 | No comment               | Enables automatic transactions (default) |
+
+## Runtime Error Capture
+
+The framework installs an `ON ERR CALL` handler around every test plus a global
+handler for non-test processes, so any 4D runtime error during a test run is
+captured and surfaced in the report.
+
+### Where captured errors show up
+
+- **Per-test errors** (raised in the test's process during the test method):
+  - `runtimeErrors[]` on the test's entry in JSON output (terse and verbose)
+  - A synthetic failed assertion with `isRuntimeError: true` in the test's `assertions[]`
+  - Marks the test failed and populates `failureCallChain`
+  - JUnit `<failure>` content
+- **Global / external errors** (raised outside any test process — workers, lazy initializers, teardown):
+  - `globalErrors[]` and `globalErrorCount` on the top-level JSON report
+  - "External runtime errors detected" block in human output
+  - JUnit `<system-err>` block — intentionally **not** counted in `<testsuites>/@errors`
+
+### Captured record schema
+
+| Field | Description |
+| --- | --- |
+| `code` | 4D error code (e.g. `54`, `-10701`) |
+| `text` | Source line / `Error method` |
+| `method` | Method or formula name (`Error formula`) |
+| `line` | Line number (`Error line`) |
+| `message` | Human-readable description (`Last errors[0].message`) |
+| `processNumber` | Process where the error fired |
+| `context` | `"local"` or `"global"` |
+| `isLocal` | True for per-test capture, false for global |
+| `callChainJSON` | JSON-serialized `Get call chain` snapshot |
+
+### Host project integration (when loaded as a component)
+
+A component's own `ON ERR CALL` cannot reach errors raised in host code. To
+capture those, the host installs its own handlers and shares
+`Storage.testErrors` (a `New shared collection`) with the component:
+
+```4d
+// RunTests.4dm  (host project)
+Use (Storage)
+    If (Storage.testErrors=Null)
+        Storage.testErrors:=New shared collection
+    Else
+        Storage.testErrors.clear()
+    End if
+End use
+
+ON ERR CALL("TestErrorHandler")
+ON ERR CALL("TestGlobalErrorHandler"; 1)
+
+Testing_RunTestsWithCs(cs; Storage; $userParams)
+```
+
+The component receives `Storage` as `$hostStorage` and drains its `testErrors`
+collection both per-process (matched by `processNumber`) and globally. The host
+must define `TestErrorHandler` and `TestGlobalErrorHandler` project methods that
+push records of the schema above onto `Storage.testErrors`.
+
+If your tests hit preemptive workers and you see
+`Cannot call error handling project method <Name>`, the handler's transitive
+call graph contains methods that are not `preemptive: capable`. Mark them
+`//%attributes = {"preemptive":"capable"}` to satisfy 4D's preemptive scope
+check.
 
 ## Trigger Control During Tests
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ EXCLUDE_TAGS_COMBINED := $(strip $(DEFAULT_EXCLUDE_TAGS) $(excludeTags))
 BASE_PARAMS := $(if $(EXCLUDE_TAGS_COMBINED),excludeTags=$(subst $(space),$(comma),$(EXCLUDE_TAGS_COMBINED)))
 
 # Build user parameters from make variables
-USER_PARAMS := $(strip $(BASE_PARAMS) $(if $(format),format=$(format)) $(if $(tags),tags=$(tags)) $(if $(test),test=$(test)) $(if $(requireTags),requireTags=$(requireTags)) $(if $(parallel),parallel=$(parallel)) $(if $(maxWorkers),maxWorkers=$(maxWorkers)))
+USER_PARAMS := $(strip $(BASE_PARAMS) $(if $(format),format=$(format)) $(if $(tags),tags=$(tags)) $(if $(test),test=$(test)) $(if $(requireTags),requireTags=$(requireTags)) $(if $(parallel),parallel=$(parallel)) $(if $(maxWorkers),maxWorkers=$(maxWorkers)) $(if $(outputPath),outputPath=$(outputPath)) $(if $(verbose),verbose=$(verbose)) $(if $(callchain),callchain=$(callchain)))
 
 # Ensure tool4d is installed (currently implemented for Linux only)
 $(TOOL4D):
@@ -97,35 +97,35 @@ test-unit-json:
 
 # Run all tests with JUnit XML output
 test-junit:
-	$(TOOL4D) $(BASE_OPTS) --user-param "format=junit"
+	$(MAKE) test format=junit
 
 # Run tests for CI/CD with custom output path
 test-ci:
-	$(TOOL4D) $(BASE_OPTS) --user-param "format=junit outputPath=test-results/junit.xml"
+	$(MAKE) test format=junit outputPath=test-results/junit.xml
 
 # Run unit tests with JUnit XML output
 test-unit-junit:
-	$(TOOL4D) $(BASE_OPTS) --user-param "format=junit tags=unit"
+	$(MAKE) test format=junit tags=unit
 
 # Run integration tests with JUnit XML output
 test-integration-junit:
-	$(TOOL4D) $(BASE_OPTS) --user-param "format=junit tags=integration"
+	$(MAKE) test format=junit tags=integration
 
 # Run tests in parallel mode
 test-parallel:
-	$(TOOL4D) $(BASE_OPTS) --user-param "parallel=true"
+	$(MAKE) test parallel=true
 
 # Run tests in parallel mode with JSON output
 test-parallel-json:
-	$(TOOL4D) $(BASE_OPTS) --user-param "parallel=true format=json"
+	$(MAKE) test parallel=true format=json
 
 # Run unit tests in parallel mode
 test-parallel-unit:
-	$(TOOL4D) $(BASE_OPTS) --user-param "parallel=true tags=unit"
+	$(MAKE) test parallel=true tags=unit
 
 # Run tests in parallel with custom worker count (usage: make test-parallel-workers WORKERS=4)
 test-parallel-workers:
-	$(TOOL4D) $(BASE_OPTS) --user-param "parallel=true maxWorkers=$(WORKERS)"
+	$(MAKE) test parallel=true maxWorkers=$(WORKERS)
 
 # Show help
 help:

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ A comprehensive unit testing framework for the 4D platform with test tagging, fi
 - **Auto test discovery** - Finds test classes ending with "Test"
 - **Test tagging** - Organize tests with `// #tags: unit, integration, slow`
 - **Flexible filtering** - Run specific tests by name, pattern, or tags
-- **Multiple output formats** - Human-readable and JSON output
-- **CI/CD ready** - Structured JSON output for automated testing
+- **Multiple output formats** - Human-readable, JSON, and JUnit XML
+- **CI/CD ready** - Structured JSON / JUnit XML output for automated testing
 - **Transaction management** - Automatic test isolation with rollback
 - **Subtests** - Run table-driven tests with `t.run`
+- **Host runtime-error capture** - When used as a component, captures and reports
+  host-side runtime errors (per-test and global) with stack chains
 
 ## Quick Example
 
@@ -62,6 +64,15 @@ tool4d --project YourProject.4DProject --startup-method "test"
 # Run with JSON output
 tool4d --project YourProject.4DProject --startup-method "test" --user-param "format=json"
 
+# Write JSON to a file (clean output, even with debug logs on stdout)
+tool4d --project YourProject.4DProject --startup-method "test" --user-param "format=json outputPath=test-results/report.json"
+
+# Include call chains on failed tests in terse JSON without going full verbose
+tool4d --project YourProject.4DProject --startup-method "test" --user-param "format=json callchain=true"
+
+# JUnit XML output (CI-friendly: failures, errors, skipped, system-err)
+tool4d --project YourProject.4DProject --startup-method "test" --user-param "format=junit outputPath=test-results/junit.xml"
+
 # Run specific tests
 tool4d --project YourProject.4DProject --startup-method "test" --user-param "test=UserServiceTest"
 tool4d --project YourProject.4DProject --startup-method "test" --user-param "test=UserServiceTest.test_user_creation"
@@ -99,16 +110,51 @@ Function _checkMathCase($t : cs.Testing; $case : Object)
 2 tests passed
 ```
 
-**JSON format:**
+**JSON format (terse — default with `format=json`):**
 ```json
 {
-  "totalTests": 2,
+  "tests": 2,
   "passed": 2,
   "failed": 0,
-  "passRate": 100,
-  "status": "success"
+  "skipped": 0,
+  "duration": 6,
+  "rate": 100.0,
+  "status": "ok",
+  "globalErrorCount": 0,
+  "globalErrors": [],
+  "testResults": [ /* per-test entries with assertions[] and runtimeErrors[] */ ],
+  "failures": [ /* one entry per failed test, includes callChain when verbose=true or callchain=true */ ]
 }
 ```
+
+External (non-test) runtime errors captured during the run live in
+`globalErrors[]` / `globalErrorCount`. JUnit output reports the same data in a
+`<system-err>` block.
+
+## Capturing Host Runtime Errors
+
+When the testing framework is loaded as a component into a host project, host-side
+code (triggers, workers, methods called by tests) can raise runtime errors that
+the component's own `ON ERR CALL` cannot reach. To capture them:
+
+1. Define `TestErrorHandler` and `TestGlobalErrorHandler` project methods in the
+   host that push `{code, text, method, line, message, processNumber, context,
+   isLocal, callChainJSON, ...}` records onto `Storage.testErrors` (a shared
+   collection).
+2. In the host's test entry point, install both handlers and pass the host's
+   `Storage` to the component:
+
+   ```4d
+   // RunTests.4dm
+   ON ERR CALL("TestErrorHandler")
+   ON ERR CALL("TestGlobalErrorHandler"; 1)
+   Testing_RunTestsWithCs(cs; Storage; $userParams)
+   ```
+
+3. The component drains `Storage.testErrors` per-test (matched by
+   `processNumber`) and globally, and surfaces them in every output format:
+   per-test `runtimeErrors[]` in JSON, top-level `globalErrors[]`, and JUnit
+   `<system-err>`.
 
 ## Documentation
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -10,6 +10,8 @@ A comprehensive unit testing framework for the 4D platform with enhanced reporti
 - [Writing Tests](#writing-tests)
 - [Assertion Library](#assertion-library)
 - [Output Formats](#output-formats)
+- [Runtime Error Capture](#runtime-error-capture)
+- [Host Project Integration](#host-project-integration)
 - [Test Filtering](#test-filtering)
 - [Test Tagging](#test-tagging)
 - [Test Lifecycle Methods](#test-lifecycle-methods)
@@ -28,7 +30,10 @@ A comprehensive unit testing framework for the 4D platform with enhanced reporti
 - **Test Tagging**: Organize and filter tests using comment-based tags
 - **Rich Assertions**: Built-in assertion library with helpful error messages
 - **Enhanced Reporting**: Detailed test results with execution times and pass rates
-- **JSON Output**: Structured output for CI/CD integration and automated processing
+- **JSON / JUnit XML Output**: Structured output for CI/CD integration and automated processing
+- **Runtime Error Capture**: Catches `ON ERR CALL` runtime errors per-test and globally, including stack chains
+- **Host Project Integration**: Captures host-side runtime errors when used as a component
+- **File Output**: Write JSON or JUnit XML directly to disk via `outputPath=`
 - **Subtest Support**: Create table-driven tests using `t.run`
 - **Mock Support**: Built-in mocking utilities for isolated unit testing
 - **CI/CD Ready**: GitHub Actions integration for automated testing
@@ -66,6 +71,15 @@ tool4d --project YourProject.4DProject --startup-method "test" --user-param "for
 
 # Verbose JSON output
 tool4d --project YourProject.4DProject --startup-method "test" --user-param "format=json verbose=true"
+
+# Include call chains on failed tests in terse JSON without going full verbose
+tool4d --project YourProject.4DProject --startup-method "test" --user-param "format=json callchain=true"
+
+# Write JSON to a file (clean output even when stdout has debug logs)
+tool4d --project YourProject.4DProject --startup-method "test" --user-param "format=json outputPath=test-results/report.json"
+
+# JUnit XML output (writes to test-results/junit.xml when outputPath is set)
+tool4d --project YourProject.4DProject --startup-method "test" --user-param "format=junit outputPath=test-results/junit.xml"
 
 # Run specific tests by pattern
 tool4d --project YourProject.4DProject --startup-method "test" --user-param "test=ExampleTest"
@@ -263,29 +277,50 @@ All tests passed! 🎉
 **Terse (Default with `format=json`):**
 ```json
 {
-  "totalTests": 5,
+  "tests": 5,
   "passed": 5,
   "failed": 0,
+  "skipped": 0,
   "duration": 45,
-  "passRate": 100,
-  "status": "success",
-  "suites": [
+  "rate": 100.0,
+  "status": "ok",
+  "globalErrorCount": 0,
+  "globalErrors": [],
+  "testResults": [
     {
-      "name": "ExampleTest",
-      "passed": 5,
-      "failed": 0,
-      "tests": [
+      "name": "test_areEqual_pass",
+      "suite": "ExampleTest",
+      "passed": true,
+      "failed": false,
+      "skipped": false,
+      "duration": 1,
+      "assertions": [
         {
-          "name": "test_areEqual_pass",
-          "passed": true
+          "passed": true,
+          "expected": 5,
+          "actual": 5,
+          "message": "Should equal",
+          "line": 12,
+          "functionName": "ExampleTest.test_areEqual_pass"
         }
-      ]
+      ],
+      "assertionCount": 1
     }
-  ]
+  ],
+  "failures": []
 }
 ```
 
+When a test fails or a runtime error fires inside a test, the test entry also
+gains a `runtimeErrors` array, and the corresponding `failures[]` entry includes
+a `callChain` collection when `verbose=true` or `callchain=true` is set.
+
 **Verbose (`format=json verbose=true`):**
+
+Verbose mode emits the full internal `results` structure plus `passRate` and
+`status: "success" | "failure"`. Call chains and per-assertion details are
+always included.
+
 ```json
 {
   "totalTests": 5,
@@ -308,6 +343,7 @@ All tests passed! 🎉
           "duration": 1,
           "suite": "ExampleTest",
           "runtimeErrors": [],
+          "assertions": [],
           "logMessages": []
         }
       ],
@@ -315,9 +351,162 @@ All tests passed! 🎉
       "failed": 0
     }
   ],
+  "globalErrors": [],
+  "globalErrorCount": 0,
   "failedTests": []
 }
 ```
+
+### JUnit XML Output
+
+`format=junit` emits a CI-compatible XML report. Counts are computed precisely:
+
+- `<testsuites>` / `<testsuite>` carry `tests`, `failures`, `errors`, `skipped`, `time`, and a valid ISO 8601 `timestamp`.
+- `failures` counts assertion failures; `errors` counts test methods that hit a runtime error. External (non-test) runtime errors are not folded into either count — they live in a `<system-err>` block on the root element.
+- Skipped tests emit a `<skipped/>` child element so JUnit consumers (Jenkins, JUnitXML, GitLab) classify them correctly.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="4D Test Results" tests="5" failures="0" errors="0" skipped="0"
+            time="0.045" timestamp="2026-05-04T16:47:10">
+  <testsuite name="ExampleTest" tests="5" failures="0" errors="0" skipped="0" time="0.045">
+    <testcase classname="ExampleTest" name="test_areEqual_pass"
+              file="testing/Project/Sources/Classes/ExampleTest.4dm" time="0.001" />
+  </testsuite>
+  <system-err><![CDATA[
+External runtime errors detected: 0
+]]></system-err>
+</testsuites>
+```
+
+### File Output (`outputPath`)
+
+Both `format=json` and `format=junit` honor an `outputPath` parameter that
+writes the report to disk instead of (or in addition to) stdout. This is the
+recommended way to consume reports programmatically — it sidesteps any
+interleaved debug logs that may be on stdout. Relative paths resolve against
+the database folder; absolute POSIX (`/...`) and Windows (`C:...`) paths are
+accepted.
+
+```bash
+tool4d --project YourProject.4DProject --startup-method "test" \
+  --user-param "format=json outputPath=test-results/report.json"
+```
+
+## Runtime Error Capture
+
+The framework installs an `ON ERR CALL` handler around each test and a global
+handler for non-test processes. Captured errors are grouped two ways:
+
+- **Per-test runtime errors** — errors raised in the test's process during the
+  test method execution. They appear as:
+  - `runtimeErrors[]` on the test (terse and verbose JSON)
+  - A synthetic failed assertion with `isRuntimeError: true` in the test's
+    `assertions[]`
+  - A `<failure>` (or `<error>`) entry in JUnit
+  - `failureCallChain` populated from the error's `callChainJSON`
+- **Global runtime errors** — errors raised outside a test process (for example
+  in background workers, lazy initializers, or tear-down). They appear as:
+  - `globalErrors[]` and `globalErrorCount` on the top-level report
+  - The "External runtime errors detected" block in human output
+  - `<system-err>` content in JUnit XML
+
+Each captured error record carries:
+
+| Field | Description |
+|---|---|
+| `code` | 4D error code (e.g. `54`, `-10701`) |
+| `text` | Source line that triggered the error |
+| `method` | Method/formula name from `Error formula` |
+| `line` | Line number from `Error line` |
+| `message` | Human-readable description (`Last errors[0].message`) |
+| `processNumber` | The 4D process where the error fired |
+| `context` | `"local"` or `"global"` |
+| `isLocal` | True for per-test errors, false for global |
+| `callChainJSON` | JSON-serialized stack chain at the moment the error fired |
+
+## Host Project Integration
+
+When the framework is loaded as a component into a host project, runtime errors
+in **host code** are not visible to the component's `ON ERR CALL` (4D scopes
+each handler to the database that registered it). To capture host-side errors,
+the host installs its own handlers and shares a `Storage.testErrors` collection
+that the component drains.
+
+### Required host-side wiring
+
+1. **Add two project methods to the host** that mirror the schema above and
+   push records onto `Storage.testErrors`:
+
+   ```4d
+   // TestErrorHandler.4dm  (host project, local handler)
+   //%attributes = {}
+   var $errorInfo : Object
+   $errorInfo:=New object(\
+     "code"; Error; \
+     "text"; Error method; \
+     "method"; Error formula; \
+     "line"; Error line; \
+     "message"; (Last errors.length>0 ? Last errors[0].message : ""); \
+     "timestamp"; Milliseconds; \
+     "processNumber"; Current process; \
+     "context"; "local"; \
+     "isLocal"; True)
+
+   If (Storage.testErrors=Null)
+     Use (Storage)
+       Storage.testErrors:=New shared collection
+     End use
+   End if
+   Use (Storage.testErrors)
+     Storage.testErrors.push(OB Copy($errorInfo; ck shared))
+   End use
+   ```
+
+   `TestGlobalErrorHandler.4dm` is the same shape but with
+   `context: "global"` and `isLocal: False`.
+
+2. **Install both handlers and pass host Storage to the component** in the
+   host's startup method:
+
+   ```4d
+   // RunTests.4dm  (host project)
+   //%attributes = {}
+   // Initialize the shared collection so handlers and the component agree on a single instance
+   Use (Storage)
+     If (Storage.testErrors=Null)
+       Storage.testErrors:=New shared collection
+     Else
+       Storage.testErrors.clear()
+     End if
+   End use
+
+   // Install host-side handlers BEFORE invoking the component
+   ON ERR CALL("TestErrorHandler")
+   ON ERR CALL("TestGlobalErrorHandler"; 1)
+
+   Testing_RunTestsWithCs(cs; Storage; Null)
+   ```
+
+3. **Ensure handler-chain methods are preemptive-safe** if your tests hit
+   preemptive workers. 4D refuses to install an `ON ERR CALL` handler from a
+   preemptive context if the handler's transitive call graph contains methods
+   that are not `preemptive: capable`. If you see
+   `Cannot call error handling project method <name>`, audit the handler's
+   callees and mark them `//%attributes = {"preemptive":"capable"}`.
+
+### What the component does
+
+`Testing_RunTestsWithCs($cs; $hostStorage; $userParams)` stores `$hostStorage`
+on the runner. During the run:
+
+- `_TestFunction._collectProcessErrors($processNumber)` drains both
+  `Storage.testErrors` (component-side) and `$hostStorage.testErrors`
+  (host-side), filtering by `processNumber` so each error is attributed to the
+  test that raised it.
+- `TestRunner._drainGlobalErrorsFromStorage()` collects `context = "global"`
+  entries from both sources for the report's `globalErrors[]`.
+- Reports surface the captured errors in every output format.
 
 ## Test Filtering
 
@@ -373,12 +562,17 @@ The framework uses a standardized key=value parameter format:
 ```
 
 ### Available Parameters
-- **`format`**: Output format (`json` or `human`)
+- **`format`**: Output format (`human` (default), `json`, or `junit`)
+- **`outputPath`**: Write JSON/JUnit report to a file instead of stdout (relative to the database folder, or absolute POSIX/Windows path)
+- **`verbose`**: Enable verbose output (`true` or `1`) — full assertion/error detail in human and JSON
+- **`callchain`**: Include `callChain` on failed tests in terse JSON (`true` or `1`); implied by `verbose=true`
 - **`test`**: Test filtering patterns
-- **`verbose`**: Enable verbose output (`true` or `1`)
 - **`tags`**: Include tests with any of these tags (comma-separated)
 - **`excludeTags`**: Exclude tests with any of these tags (comma-separated)
 - **`requireTags`**: Include only tests with ALL of these tags (comma-separated)
+- **`parallel`**: Enable parallel suite execution (`true` or `1`)
+- **`maxWorkers`**: Cap on concurrent workers (default: CPU core count, max: 8)
+- **`triggers`**: Default trigger behavior (`enabled` or `disabled`; default: disabled)
 
 
 ### Pattern Matching Rules

--- a/testing/Project/Sources/Classes/Assert.4dm
+++ b/testing/Project/Sources/Classes/Assert.4dm
@@ -246,9 +246,14 @@ Function areDeepEqual($t : Object; $expected : Variant; $actual : Variant; $mess
 	End if 
 	
 Function _recordAssertion($t : Object; $passed : Boolean; $expected : Variant; $actual : Variant; $message : Text; $callChain : Collection)
-	// Note: Line numbers from 4D's call chain are not reliable for showing source line locations
-	// They reference internal function offsets rather than actual source lines
-	// Therefore, we omit line numbers from assertion records
+	var $line : Integer
+	$line:=This:C1470._findTestLine($t; $callChain)
+	
+	var $functionName : Text
+	$functionName:=""
+	If ($t.testClassName#Null:C1517) && ($t.testClassName#"") && ($t.testFunctionName#Null:C1517) && ($t.testFunctionName#"")
+		$functionName:=$t.testClassName+"."+$t.testFunctionName
+	End if
 	
 	var $assertInfo : Object
 	$assertInfo:=New object:C1471(\
@@ -257,8 +262,36 @@ Function _recordAssertion($t : Object; $passed : Boolean; $expected : Variant; $
 		"actual"; This:C1470._sanitizeValue($actual); \
 		"message"; $message\
 		)
-	$t.assertions.push($assertInfo)
 	
+	If ($line>0)
+		$assertInfo.line:=$line
+	End if
+	If ($functionName#"")
+		$assertInfo.functionName:=$functionName
+	End if
+	
+	$t.assertions.push($assertInfo)
+
+Function _findTestLine($t : Object; $callChain : Collection) : Integer
+	var $chain : Collection
+	If ($callChain#Null:C1517) && ($callChain.length>0)
+		$chain:=$callChain
+	Else
+		$chain:=Get call chain:C1662
+	End if
+	
+	If ($t.testFunctionName=Null:C1517) || ($t.testFunctionName="")
+		return 0
+	End if
+	
+	var $frame : Object
+	For each ($frame; $chain)
+		If ($frame.name=$t.testFunctionName)
+			return $frame.line
+		End if
+	End for each
+	return 0
+
 Function _sanitizeValue($value : Variant) : Variant
 	var $type : Integer
 	$type:=Value type:C1509($value)

--- a/testing/Project/Sources/Classes/TestRunner.4dm
+++ b/testing/Project/Sources/Classes/TestRunner.4dm
@@ -653,13 +653,12 @@ Function _buildJUnitXML() : Text
 	var $totalTime : Real
 	$totalTime:=This:C1470.results.duration/1000  // Convert ms to seconds
 	
-	// Calculate errors and failures separately
+	// JUnit testsuites/@errors counts only TEST errors (failed tests with a runtime
+	// error). External (non-test) runtime errors live in <system-err>; including
+	// them here would inflate @errors and drive @failures negative.
 	var $totalErrors; $totalFailures : Integer
-	var $globalErrorCount : Integer
 	$totalErrors:=This:C1470._countTestsWithRuntimeErrors()
-	$globalErrorCount:=This:C1470.results.globalErrorCount
-	$totalErrors:=$totalErrors+$globalErrorCount
-	$totalFailures:=This:C1470.results.failed-$totalErrors  // Failures are failed tests without runtime errors
+	$totalFailures:=This:C1470.results.failed-$totalErrors  // assertion failures
 	
 	// XML header and root testsuites element
 	$xml:="<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n"
@@ -667,6 +666,7 @@ Function _buildJUnitXML() : Text
 	$xml:=$xml+" tests=\""+String:C10(This:C1470.results.totalTests)+"\""
 	$xml:=$xml+" failures=\""+String:C10($totalFailures)+"\""
 	$xml:=$xml+" errors=\""+String:C10($totalErrors)+"\""
+	$xml:=$xml+" skipped=\""+String:C10(This:C1470.results.skipped)+"\""
 	$xml:=$xml+" time=\""+String:C10($totalTime; "##0.000")+"\""
 	$xml:=$xml+" timestamp=\""+This:C1470._formatTimestamp(This:C1470.results.startTime)+"\">\r\n"
 	
@@ -696,15 +696,17 @@ Function _buildTestSuiteXML($suite : Object) : Text
 	End for each 
 	
 	// Calculate errors and failures for this suite
-	var $suiteErrors; $suiteFailures : Integer
+	var $suiteErrors; $suiteFailures; $suiteSkipped : Integer
 	$suiteErrors:=This:C1470._countSuiteTestsWithRuntimeErrors($suite)
 	$suiteFailures:=$suite.failed-$suiteErrors
+	$suiteSkipped:=Num:C11($suite.skipped)
 	
 	// Build testsuite element
 	$xml:="  <testsuite name=\""+This:C1470._escapeXMLAttribute($suite.name)+"\""
 	$xml:=$xml+" tests=\""+String:C10($suite.tests.length)+"\""
 	$xml:=$xml+" failures=\""+String:C10($suiteFailures)+"\""
 	$xml:=$xml+" errors=\""+String:C10($suiteErrors)+"\""
+	$xml:=$xml+" skipped=\""+String:C10($suiteSkipped)+"\""
 	$xml:=$xml+" time=\""+String:C10($suiteTotalTime; "##0.000")+"\""
 	$xml:=$xml+">\r\n"
 	
@@ -729,14 +731,20 @@ Function _buildTestCaseXML($test : Object) : Text
 	$xml:=$xml+" file=\"testing/Project/Sources/Classes/"+This:C1470._escapeXMLAttribute($test.suite)+".4dm\""
 	$xml:=$xml+" time=\""+String:C10($testTime; "##0.000")+"\""
 	
-	// If test failed, add failure element
-	If ($test.failed)
-		$xml:=$xml+">\r\n"
-		$xml:=$xml+This:C1470._buildFailureXML($test)
-		$xml:=$xml+"    </testcase>\r\n"
-	Else 
-		$xml:=$xml+" />\r\n"
-	End if 
+	Case of 
+		: ($test.failed)
+			$xml:=$xml+">\r\n"
+			$xml:=$xml+This:C1470._buildFailureXML($test)
+			$xml:=$xml+"    </testcase>\r\n"
+		: (Bool:C1537($test.skipped))
+			// JUnit consumers (Jenkins, JUnitXML, etc.) require a <skipped/> child
+			// to recognize a testcase as skipped vs. passed.
+			$xml:=$xml+">\r\n"
+			$xml:=$xml+"      <skipped/>\r\n"
+			$xml:=$xml+"    </testcase>\r\n"
+		Else 
+			$xml:=$xml+" />\r\n"
+	End case 
 	
 	return $xml
 	
@@ -837,13 +845,13 @@ Function _resolveOutputFile($outputPath : Text) : 4D:C1709.File
 	return $baseFolder.file($pathParts[$pathParts.length-1])
 	
 Function _formatTimestamp($milliseconds : Integer) : Text
-	// Convert milliseconds to ISO 8601 timestamp
-	var $date : Date
-	var $time : Time
+	// ISO 8601 local timestamp: YYYY-MM-DDTHH:MM:SS
+	// Note: $milliseconds is a Milliseconds counter (relative to app start), so we
+	// can't reconstruct a wall-clock timestamp from it. Use Current date/time.
+	// String(Current date; ISO date GMT) returns "YYYY-MM-DDT00:00:00Z"; take only
+	// the date prefix and append the local time. (No "Z" — these are local values.)
 	var $timestamp : Text
-	
-	// For now, use current timestamp - could be enhanced to use actual start time
-	$timestamp:=String:C10(Current date:C33; ISO date GMT:K1:10)+"T"+String:C10(Current time:C178; HH MM SS:K7:1)
+	$timestamp:=Substring:C12(String:C10(Current date:C33; ISO date GMT:K1:10); 1; 10)+"T"+String:C10(Current time:C178; HH MM SS:K7:1)
 	return $timestamp
 	
 Function _logFooter()

--- a/testing/Project/Sources/Classes/TestRunner.4dm
+++ b/testing/Project/Sources/Classes/TestRunner.4dm
@@ -4,6 +4,7 @@ property testSuites : Collection  // Collection of cs._TestSuite
 property results : Object  // Test results summary
 property outputFormat : Text  // "human", "json", "junit"
 property verboseOutput : Boolean  // Whether to include detailed information
+property callChainOutput : Boolean  // Terse JSON: call chain when verbose or callchain=true
 property testPatterns : Collection  // Collection of test patterns to match
 property includeTags : Collection  // Tags to include (OR logic)
 property excludeTags : Collection  // Tags to exclude
@@ -27,8 +28,13 @@ Function run()
 	This:C1470._prepareErrorHandlingStorage()
 	var $handlerState : Object
 	$handlerState:=This:C1470._installErrorHandler()
+	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] run: before _runInternal\r\n"; Information message:K38:1)
 	This:C1470._runInternal()
+	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] run: after _runInternal\r\n"; Information message:K38:1)
 	This:C1470._captureGlobalErrors()
+	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] run: after _captureGlobalErrors\r\n"; Information message:K38:1)
+	This:C1470._generateReport()
+	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] run: after _generateReport\r\n"; Information message:K38:1)
 	This:C1470._restoreErrorHandler($handlerState)
 	
 Function _determineTriggerDefaultBehavior()
@@ -103,6 +109,18 @@ Function _prepareErrorHandlingStorage()
 			Storage:C1525.testErrors.clear()
 		End if 
 	End use 
+
+	// Prepare host Storage for error collection (when running as a component,
+	// the host's error handlers write to host Storage)
+	If (This:C1470.hostStorage#Null:C1517)
+		Use (This:C1470.hostStorage)
+			If (This:C1470.hostStorage.testErrors=Null:C1517)
+				This:C1470.hostStorage.testErrors:=New shared collection:C1527
+			Else
+				This:C1470.hostStorage.testErrors.clear()
+			End if
+		End use
+	End if
 	
 Function _runInternal()
 	This:C1470._prepareSuites()
@@ -121,14 +139,18 @@ Function _runSuitesSequentially()
 	End if 
 	
 	var $testSuite : cs:C1710._TestSuite
+	var $suiteIndex : Integer
+	$suiteIndex:=0
 	For each ($testSuite; This:C1470.testSuites)
+		$suiteIndex+=1
+		LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] suite "+String:C10($suiteIndex)+"/"+String:C10(This:C1470.testSuites.length)+": "+$testSuite.class.name+" ("+String:C10($testSuite.testFunctions.length)+" tests)\r\n"; Information message:K38:1)
 		$testSuite.run()
 		This:C1470._collectSuiteResults($testSuite)
 	End for each 
+	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _runSuitesSequentially: all suites done\r\n"; Information message:K38:1)
 	
 	This:C1470.results.endTime:=Milliseconds:C459
 	This:C1470.results.duration:=This:C1470.results.endTime-This:C1470.results.startTime
-	This:C1470._generateReport()
 	
 Function _installErrorHandler() : Object
 	var $previousErrorHandler : Text
@@ -304,11 +326,10 @@ Function _collectSuiteResults($testSuite : cs:C1710._TestSuite)
 						End if 
 					End if 
 					
-					// Add call chain information if available
-					If ($testResult.callChain#Null:C1517)
-						$errorDetails:=$errorDetails+"\r\n"+This:C1470._formatCallChain($testResult.callChain)
-					End if 
-					LOG EVENT:C667(Into system standard outputs:K38:9; "  ✗ "+$testResult.name+" ("+String:C10($testResult.duration)+"ms)"+$errorDetails+"\r\n"; Error message:K38:3)
+				If (This:C1470.verboseOutput) && ($testResult.callChain#Null:C1517)
+					$errorDetails:=$errorDetails+"\r\n"+This:C1470._formatCallChain($testResult.callChain)
+				End if 
+				LOG EVENT:C667(Into system standard outputs:K38:9; "  ✗ "+$testResult.name+" ("+String:C10($testResult.duration)+"ms)"+$errorDetails+"\r\n"; Error message:K38:3)
 				End if 
 			End if 
 		End if 
@@ -349,6 +370,21 @@ Function _drainGlobalErrorsFromStorage() : Collection
 			End for 
 		End use 
 	End if 
+
+	// Drain from host Storage (when running as a component)
+	If (This:C1470.hostStorage#Null:C1517) && (This:C1470.hostStorage.testErrors#Null:C1517)
+		Use (This:C1470.hostStorage.testErrors)
+			For ($index; This:C1470.hostStorage.testErrors.length-1; 0; -1)
+				$error:=This:C1470.hostStorage.testErrors[$index]
+				$context:=$error.context || ""
+
+				If ($context="global")
+					$globalErrors.push(OB Copy:C1225($error))
+					This:C1470.hostStorage.testErrors.remove($index)
+				End if
+			End for
+		End use
+	End if
 	
 	return $globalErrors
 	
@@ -381,6 +417,7 @@ Function _formatGlobalErrorForLog($error : Object) : Text
 	return $message
 	
 Function _generateReport()
+	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateReport: format="+This:C1470.outputFormat+"\r\n"; Information message:K38:1)
 	If (This:C1470.outputFormat="json")
 		This:C1470._generateJSONReport()
 	Else 
@@ -392,8 +429,10 @@ Function _generateReport()
 			End if 
 		End if 
 	End if 
+	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateReport: done\r\n"; Information message:K38:1)
 	
 Function _generateHumanReport()
+	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateHumanReport: start\r\n"; Information message:K38:1)
 	var $passRate : Real
 	var $effectiveTotal : Integer
 	$effectiveTotal:=This:C1470.results.totalTests-This:C1470.results.skipped
@@ -436,8 +475,7 @@ Function _generateHumanReport()
 			
 			LOG EVENT:C667(Into system standard outputs:K38:9; "- "+$failedTest.name+$failureReason+"\r\n"; Error message:K38:3)
 			
-			// Add detailed call chain if available
-			If ($failedTest.callChain#Null:C1517)
+			If (This:C1470.verboseOutput) && ($failedTest.callChain#Null:C1517)
 				LOG EVENT:C667(Into system standard outputs:K38:9; This:C1470._formatCallChain($failedTest.callChain)+"\r\n"; Error message:K38:3)
 			End if 
 		End for each 
@@ -456,6 +494,7 @@ Function _generateHumanReport()
 	This:C1470._logFooter()
 	
 Function _generateJSONReport()
+	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateJSONReport: start, totalTests="+String:C10(This:C1470.results.totalTests)+"\r\n"; Information message:K38:1)
 	var $passRate : Real
 	var $effectiveTotal : Integer
 	$effectiveTotal:=This:C1470.results.totalTests-This:C1470.results.skipped
@@ -472,10 +511,12 @@ Function _generateJSONReport()
 	
 	If (This:C1470.verboseOutput)
 		// Verbose mode: include all details (original format)
+		LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateJSONReport: verbose OB Copy\r\n"; Information message:K38:1)
 		$jsonReport:=OB Copy:C1225(This:C1470.results)
 		$jsonReport.passRate:=$passRate
 		$jsonReport.status:=$hasFailures ? "failure" : "success"
 	Else 
+		LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateJSONReport: terse mode\r\n"; Information message:K38:1)
 		// Terse mode: minimal information
 		$jsonReport:=New object:C1471(\
 			"tests"; This:C1470.results.totalTests; \
@@ -491,14 +532,15 @@ Function _generateJSONReport()
 			"status"; $hasFailures ? "fail" : "ok"\
 			)
 		
-		// Include individual test results with assertions
+		// Include individual test results with assertions and runtime errors
 		var $testResults : Collection
 		$testResults:=[]
 		var $suite : Object
 		var $test : Object
 		For each ($suite; This:C1470.results.suites)
 			For each ($test; $suite.tests)
-				$testResults.push(New object:C1471(\
+				var $testEntry : Object
+				$testEntry:=New object:C1471(\
 					"name"; $test.name; \
 					"suite"; $test.suite; \
 					"passed"; Not:C34($test.failed) && Not:C34($test.skipped); \
@@ -507,7 +549,14 @@ Function _generateJSONReport()
 					"duration"; $test.duration; \
 					"assertions"; $test.assertions; \
 					"assertionCount"; $test.assertionCount\
-					))
+					)
+				
+				// Include runtime errors if any
+				If ($test.runtimeErrors#Null:C1517) && ($test.runtimeErrors.length>0)
+					$testEntry.runtimeErrors:=$test.runtimeErrors
+				End if
+				
+				$testResults.push($testEntry)
 			End for each 
 		End for each 
 		$jsonReport.testResults:=$testResults
@@ -529,8 +578,8 @@ Function _generateJSONReport()
 					End if 
 				End if 
 				
-				// Include call chain in verbose JSON output
-				If (This:C1470.verboseOutput) && ($failedTest.callChain#Null:C1517)
+				// Terse JSON: callChain when verbose or callchain=true (see _determineOutputFormat)
+				If (This:C1470.callChainOutput) && ($failedTest.callChain#Null:C1517)
 					$terseFailure.callChain:=$failedTest.callChain
 				End if 
 				$failedTests.push($terseFailure)
@@ -555,10 +604,34 @@ Function _generateJSONReport()
 		End if 
 	End if 
 	
+	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateJSONReport: before JSON Stringify\r\n"; Information message:K38:1)
 	var $jsonString : Text
 	$jsonString:=JSON Stringify:C1217($jsonReport; *)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateJSONReport: after JSON Stringify, length="+String:C10(Length:C16($jsonString))+"\r\n"; Information message:K38:1)
 	
-	LOG EVENT:C667(Into system standard outputs:K38:9; $jsonString; Information message:K38:1)
+	var $outputPath : Text
+	$outputPath:=This:C1470.userParams.outputPath || ""
+	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateJSONReport: outputPath='"+$outputPath+"'\r\n"; Information message:K38:1)
+	
+	If ($outputPath#"")
+		This:C1470._writeJSONToFile($jsonString; $outputPath)
+	Else 
+		LOG EVENT:C667(Into system standard outputs:K38:9; $jsonString; Information message:K38:1)
+	End if 
+	
+Function _writeJSONToFile($jsonContent : Text; $outputPath : Text)
+	var $jsonFile : 4D:C1709.File
+	$jsonFile:=This:C1470._resolveOutputFile($outputPath)
+	
+	var $outputFolder : 4D:C1709.Folder
+	$outputFolder:=$jsonFile.parent
+	If (Not:C34($outputFolder.exists))
+		$outputFolder.create()
+	End if 
+	
+	$jsonFile.setText($jsonContent; "UTF-8")
+	
+	LOG EVENT:C667(Into system standard outputs:K38:9; "JSON results written to: "+$jsonFile.platformPath+"\r\n"; Information message:K38:1)
 	
 Function _generateJUnitXMLReport()
 	var $params : Object
@@ -718,32 +791,15 @@ Function _buildGlobalErrorsSystemErr() : Text
 	return $xml
 	
 Function _writeJUnitXMLToFile($xmlContent : Text; $outputPath : Text)
-	// Parse the path to determine folder and filename
-	var $pathParts : Collection
-	$pathParts:=Split string:C1554($outputPath; "/")
+	var $xmlFile : 4D:C1709.File
+	$xmlFile:=This:C1470._resolveOutputFile($outputPath)
 	
-	// Build output folder path
 	var $outputFolder : 4D:C1709.Folder
-	If ($pathParts.length>1)
-		var $folderPath : Text
-		$folderPath:=$pathParts.slice(0; $pathParts.length-1).join("/")
-		$outputFolder:=Folder:C1567(fk database folder:K87:14; *).folder($folderPath)
-	Else 
-		$outputFolder:=Folder:C1567(fk database folder:K87:14; *)
-	End if 
-	
-	// Create output folder if it doesn't exist
+	$outputFolder:=$xmlFile.parent
 	If (Not:C34($outputFolder.exists))
 		$outputFolder.create()
 	End if 
 	
-	// Get filename
-	var $filename : Text
-	$filename:=$pathParts[$pathParts.length-1]
-	
-	// Create and write XML file
-	var $xmlFile : 4D:C1709.File
-	$xmlFile:=$outputFolder.file($filename)
 	$xmlFile.setText($xmlContent; "UTF-8")
 	
 	// Log file location for CI visibility
@@ -760,6 +816,25 @@ Function _escapeXMLAttribute($text : Text) : Text
 	$escaped:=Replace string:C233($escaped; "\""; "&quot;")
 	$escaped:=Replace string:C233($escaped; "'"; "&apos;")
 	return $escaped
+	
+Function _resolveOutputFile($outputPath : Text) : 4D:C1709.File
+	If (($outputPath[[1]]="/") || (Position:C15(":"; $outputPath)>0))
+		return File:C1566($outputPath; fk posix path:K87:1)
+	End if 
+	
+	var $pathParts : Collection
+	$pathParts:=Split string:C1554($outputPath; "/")
+	
+	var $baseFolder : 4D:C1709.Folder
+	If ($pathParts.length>1)
+		var $folderPath : Text
+		$folderPath:=$pathParts.slice(0; $pathParts.length-1).join("/")
+		$baseFolder:=Folder:C1567(fk database folder:K87:14; *).folder($folderPath)
+	Else 
+		$baseFolder:=Folder:C1567(fk database folder:K87:14; *)
+	End if 
+	
+	return $baseFolder.file($pathParts[$pathParts.length-1])
 	
 Function _formatTimestamp($milliseconds : Integer) : Text
 	// Convert milliseconds to ISO 8601 timestamp
@@ -811,8 +886,9 @@ Function _determineOutputFormat()
 		End if 
 	End if 
 	
-	// Check for verbose flag
+	// Terse JSON: call chains only when verbose or explicit callchain=true
 	This:C1470.verboseOutput:=($params.verbose="true")
+	This:C1470.callChainOutput:=This:C1470.verboseOutput || ($params.callchain="true")
 	
 Function _parseTestPatterns()
 	var $params : Object

--- a/testing/Project/Sources/Classes/Testing.4dm
+++ b/testing/Project/Sources/Classes/Testing.4dm
@@ -8,6 +8,8 @@ property assert : cs:C1710.Assert
 property stats : cs:C1710.UnitStatsTracker
 property failureCallChain : Collection
 property classInstance : 4D:C1709.Object
+property testFunctionName : Text
+property testClassName : Text
 
 Class constructor()
 	This:C1470.failed:=False:C215
@@ -17,6 +19,8 @@ Class constructor()
         This:C1470.assert:=cs:C1710.Assert.new()
         This:C1470.stats:=cs:C1710.UnitStatsTracker.new()
         This:C1470.failureCallChain:=Null
+        This:C1470.testFunctionName:=""
+        This:C1470.testClassName:=""
 	
 Function log($message : Text)
 	This:C1470.logMessages.push($message)
@@ -65,6 +69,8 @@ Function resetForNewTest()
         This:C1470.assertions:=[]
         This:C1470.stats.resetStatistics()
         This:C1470.failureCallChain:=Null
+        This:C1470.testFunctionName:=""
+        This:C1470.testClassName:=""
 	
 Function run($name : Text; $subtest : 4D:C1709.Function; $data : Variant) : Boolean
         // Execute a named subtest with its own Testing context

--- a/testing/Project/Sources/Classes/_TestFunction.4dm
+++ b/testing/Project/Sources/Classes/_TestFunction.4dm
@@ -31,6 +31,8 @@ Function run()
 
         // Reset the testing context for this test
         This:C1470.t.resetForNewTest()
+        This:C1470.t.testFunctionName:=This:C1470.functionName
+        This:C1470.t.testClassName:=This:C1470.class.name
 
         var $processNumber : Integer
         $processNumber:=Current process:C322
@@ -57,38 +59,42 @@ Function run()
 
 	// Start transaction if configured to use transactions
 	var $transactionStarted : Boolean
-	$transactionStarted:=False
+	$transactionStarted:=False:C215
 	If (This:C1470.useTransactions)
 		START TRANSACTION:C239
-		$transactionStarted:=True
-	End if 
-	
-        This:C1470.function.apply(This:C1470.classInstance; [This:C1470.t])
-	
-        // Capture any runtime errors that occurred in this process
-        var $processErrors : Collection
-        $processErrors:=This:C1470._collectProcessErrors($processNumber)
+		$transactionStarted:=True:C214
+	End if
 
-        If ($processErrors.length>0)
-                var $error : Object
-                For each ($error; $processErrors)
-                        This:C1470.runtimeErrors.push($error)
-                End for each
+	This:C1470.function.apply(This:C1470.classInstance; [This:C1470.t])
 
-                // Mark test as failed if runtime errors occurred
-                This:C1470.t.fail()
-        End if
-	
-	// Handle transaction cleanup
-	If ($transactionStarted)
-		If (This:C1470.t.failed)
-			// Cancel transaction if test failed
-			CANCEL TRANSACTION:C241
-		Else
-			// Always cancel transaction to ensure test isolation
-			// Tests should not persist data changes by default
-			CANCEL TRANSACTION:C241
+	// Collect errors captured by ON ERR CALL handler in Storage.testErrors
+	var $processErrors : Collection
+	$processErrors:=This:C1470._collectProcessErrors($processNumber)
+
+	If ($processErrors.length>0)
+		var $qualifiedName : Text
+		$qualifiedName:=This:C1470.class.name+"."+This:C1470.functionName
+		
+		var $error : Object
+		For each ($error; $processErrors)
+			$error.functionName:=$qualifiedName
+			$error.formula:=$error.method || ""
+			This:C1470.runtimeErrors.push($error)
+			This:C1470._addRuntimeErrorAsAssertion($error)
+		End for each
+		This:C1470.t.failed:=True:C214
+		
+		If (This:C1470.t.failureCallChain=Null:C1517)
+			var $callChainText : Text
+			$callChainText:=$processErrors[0].callChainJSON || ""
+			If ($callChainText#"")
+				This:C1470.t.failureCallChain:=JSON Parse:C1218($callChainText)
+			End if
 		End if
+	End if
+
+	If ($transactionStarted)
+		CANCEL TRANSACTION:C241
 	End if
 
 	// Restore default trigger behavior after test
@@ -384,6 +390,22 @@ Function _restoreTriggerControl()
 		This:C1470.runner.restoreDefaultTriggerBehavior()
 	End if
 
+Function _addRuntimeErrorAsAssertion($error : Object)
+	var $errorMessage : Text
+	$errorMessage:=$error.message || $error.method || ("Error "+String:C10($error.code))
+	
+	var $assertInfo : Object
+	$assertInfo:=New object:C1471(\
+		"passed"; False:C215; \
+		"expected"; Null:C1517; \
+		"actual"; "["+String:C10($error.code)+"] "+$errorMessage; \
+		"message"; "Runtime error: "+$errorMessage; \
+		"line"; $error.line; \
+		"functionName"; This:C1470.class.name+"."+This:C1470.functionName; \
+		"isRuntimeError"; True:C214\
+		)
+	This:C1470.t.assertions.push($assertInfo)
+
 Function _clearProcessErrors($processNumber : Integer)
         If (Storage:C1525.testErrors#Null:C1517)
                 Use (Storage:C1525.testErrors)
@@ -394,6 +416,21 @@ Function _clearProcessErrors($processNumber : Integer)
 
                                 If (This:C1470._errorBelongsToProcess($error; $processNumber))
                                         Storage:C1525.testErrors.remove($index)
+                                End if
+                        End for
+                End use
+        End if
+
+        // Clear errors from host Storage (when running as a component)
+        var $hostStorage : Object
+        $hostStorage:=This:C1470._getHostStorage()
+        If ($hostStorage#Null:C1517) && ($hostStorage.testErrors#Null:C1517)
+                Use ($hostStorage.testErrors)
+                        For ($index; $hostStorage.testErrors.length-1; 0; -1)
+                                $error:=$hostStorage.testErrors[$index]
+
+                                If (This:C1470._errorBelongsToProcess($error; $processNumber))
+                                        $hostStorage.testErrors.remove($index)
                                 End if
                         End for
                 End use
@@ -418,17 +455,32 @@ Function _collectProcessErrors($processNumber : Integer) : Collection
                 End use
         End if
 
+        // Collect from host Storage (when running as a component)
+        var $hostStorage : Object
+        $hostStorage:=This:C1470._getHostStorage()
+        If ($hostStorage#Null:C1517) && ($hostStorage.testErrors#Null:C1517)
+                Use ($hostStorage.testErrors)
+                        For ($index; $hostStorage.testErrors.length-1; 0; -1)
+                                $error:=$hostStorage.testErrors[$index]
+
+                                If (This:C1470._errorBelongsToProcess($error; $processNumber))
+                                        $processErrors.push(OB Copy:C1225($error))
+                                        $hostStorage.testErrors.remove($index)
+                                End if
+                        End for
+                End use
+        End if
+
         return $processErrors
+
+Function _getHostStorage() : Object
+        If (This:C1470.runner#Null:C1517) && (This:C1470.runner.hostStorage#Null:C1517)
+                return This:C1470.runner.hostStorage
+        End if
+        return Null:C1517
 
 Function _errorBelongsToProcess($error : Object; $processNumber : Integer) : Boolean
         If ($error=Null:C1517)
-                return False:C215
-        End if
-
-        var $context : Text
-        $context:=$error.context || ""
-
-        If ($context="global")
                 return False:C215
         End if
 
@@ -436,5 +488,4 @@ Function _errorBelongsToProcess($error : Object; $processNumber : Integer) : Boo
                 return ($error.processNumber=$processNumber)
         End if
 
-        // Legacy support: assume errors without process information belong to the current process
-        return True:C214
+        return False:C215

--- a/testing/Project/Sources/Methods/TestErrorHandler.4dm
+++ b/testing/Project/Sources/Methods/TestErrorHandler.4dm
@@ -19,6 +19,15 @@ $processNumber:=Current process:C322
 $context:="local"
 $isLocalProcess:=True:C214
 
+// Get human-readable error description from Last errors
+var $errorMessage : Text
+$errorMessage:=""
+var $lastErrors : Collection
+$lastErrors:=Last errors
+If ($lastErrors#Null:C1517) && ($lastErrors.length>0)
+        $errorMessage:=$lastErrors[0].message
+End if
+
 // Store error information in Storage for later retrieval
 If (Storage:C1525.testErrors=Null:C1517)
         Use (Storage:C1525)
@@ -26,16 +35,34 @@ If (Storage:C1525.testErrors=Null:C1517)
         End use
 End if
 
+var $rawChain : Collection
+$rawChain:=Get call chain:C1662
+// Strip the error handler and all framework internals from the chain
+var $filteredChain : Collection
+$filteredChain:=New collection:C1472
+var $entry : Object
+For each ($entry; $rawChain)
+	// Drop the handler frame only — do not strip all "testing" DB frames, or real
+	// test methods in the component disappear from the chain (review: PR #30).
+	If ($entry.name#"TestErrorHandler")
+		$filteredChain.push($entry)
+	End if
+End for each
+var $callChainJSON : Text
+$callChainJSON:=JSON Stringify:C1217($filteredChain)
+
 var $errorInfo : Object
 $errorInfo:=New object:C1471(\
 "code"; $errorCode; \
 "text"; $errorText; \
 "method"; $errorMethod; \
 "line"; $errorLine; \
+"message"; $errorMessage; \
 "timestamp"; Milliseconds:C459; \
 "processNumber"; $processNumber; \
 "context"; $context; \
-"isLocal"; $isLocalProcess\
+"isLocal"; $isLocalProcess; \
+"callChainJSON"; $callChainJSON\
 )
 
 Use (Storage:C1525.testErrors)

--- a/testing/Project/Sources/Methods/TestGlobalErrorHandler.4dm
+++ b/testing/Project/Sources/Methods/TestGlobalErrorHandler.4dm
@@ -19,11 +19,33 @@ $processNumber:=Current process:C322
 $context:="global"
 $isLocalProcess:=False:C215
 
+// Get human-readable error description from Last errors
+var $errorMessage : Text
+$errorMessage:=""
+var $lastErrors : Collection
+$lastErrors:=Last errors
+If ($lastErrors#Null:C1517) && ($lastErrors.length>0)
+        $errorMessage:=$lastErrors[0].message
+End if
+
 If (Storage:C1525.testErrors=Null:C1517)
         Use (Storage:C1525)
                 Storage:C1525.testErrors:=New shared collection:C1527
         End use
 End if
+
+var $rawChain : Collection
+$rawChain:=Get call chain:C1662
+var $filteredChain : Collection
+$filteredChain:=New collection:C1472
+var $entry : Object
+For each ($entry; $rawChain)
+	If ($entry.name#"TestGlobalErrorHandler")
+		$filteredChain.push($entry)
+	End if
+End for each
+var $callChainJSON : Text
+$callChainJSON:=JSON Stringify:C1217($filteredChain)
 
 var $errorInfo : Object
 $errorInfo:=New object:C1471(\
@@ -31,10 +53,12 @@ $errorInfo:=New object:C1471(\
 "text"; $errorText; \
 "method"; $errorMethod; \
 "line"; $errorLine; \
+"message"; $errorMessage; \
 "timestamp"; Milliseconds:C459; \
 "processNumber"; $processNumber; \
 "context"; $context; \
-"isLocal"; $isLocalProcess\
+"isLocal"; $isLocalProcess; \
+"callChainJSON"; $callChainJSON\
 )
 
 Use (Storage:C1525.testErrors)

--- a/testing/Resources/en.lproj/syntaxEN.json
+++ b/testing/Resources/en.lproj/syntaxEN.json
@@ -74,14 +74,7 @@
 				"Summary": ""
 			}
 		},
-		"_ParameterParsingTest": {
-			"new()": {
-				"Syntax": "**.new**()",
-				"Params": [],
-				"Summary": ""
-			}
-		},
-		"UnitStatsDetail": {
+		"_TestingTest": {
 			"new()": {
 				"Syntax": "**.new**()",
 				"Params": [],
@@ -125,7 +118,7 @@
 				"Summary": ""
 			}
 		},
-		"_TestingTest": {
+		"_ParameterParsingTest": {
 			"new()": {
 				"Syntax": "**.new**()",
 				"Params": [],
@@ -188,13 +181,6 @@
 				"Summary": ""
 			}
 		},
-		"TriggerConfigurationTest": {
-			"new()": {
-				"Syntax": "**.new**()",
-				"Params": [],
-				"Summary": ""
-			}
-		},
 		"TriggerControlTest": {
 			"new()": {
 				"Syntax": "**.new**()",
@@ -216,7 +202,21 @@
 				"Summary": ""
 			}
 		},
+		"_AssertDeepEqualTest": {
+			"new()": {
+				"Syntax": "**.new**()",
+				"Params": [],
+				"Summary": ""
+			}
+		},
 		"_ErrorHandlingTest": {
+			"new()": {
+				"Syntax": "**.new**()",
+				"Params": [],
+				"Summary": ""
+			}
+		},
+		"UnitStatsDetail": {
 			"new()": {
 				"Syntax": "**.new**()",
 				"Params": [],
@@ -293,6 +293,13 @@
 						"->"
 					]
 				],
+				"Summary": ""
+			}
+		},
+		"TriggerConfigurationTest": {
+			"new()": {
+				"Syntax": "**.new**()",
+				"Params": [],
 				"Summary": ""
 			}
 		}
@@ -728,11 +735,17 @@
 		"disableTriggersByDefault": {
 			"Syntax": "disableTriggersByDefault : Boolean"
 		},
+		"userParams": {
+			"Syntax": "userParams : Object"
+		},
 		"includeTags": {
 			"Syntax": "includeTags : Collection"
 		},
 		"testPatterns": {
 			"Syntax": "testPatterns : Collection"
+		},
+		"callChainOutput": {
+			"Syntax": "callChainOutput : Boolean"
 		},
 		"hostStorage": {
 			"Syntax": "hostStorage : 4D.Object"
@@ -752,14 +765,11 @@
 		"excludeTags": {
 			"Syntax": "excludeTags : Collection"
 		},
-		"classStore": {
-			"Syntax": "classStore : 4D.Object"
-		},
 		"results": {
 			"Syntax": "results : Object"
 		},
-		"userParams": {
-			"Syntax": "userParams : Object"
+		"classStore": {
+			"Syntax": "classStore : 4D.Object"
 		}
 	},
 	"_MockingExampleTest": {
@@ -819,9 +829,9 @@
 			"Summary": ""
 		}
 	},
-	"_ParameterParsingTest": {
-		"test_edge_case_patterns()": {
-			"Syntax": "**.test_edge_case_patterns**( *t* : cs.Testing.Testing )",
+	"_TestingTest": {
+		"test_run_subtest_stats_isolated()": {
+			"Syntax": "**.test_run_subtest_stats_isolated**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -831,8 +841,8 @@
 			],
 			"Summary": ""
 		},
-		"test_wildcard_suite_filtering()": {
-			"Syntax": "**.test_wildcard_suite_filtering**( *t* : cs.Testing.Testing )",
+		"test_run_uses_parent_context()": {
+			"Syntax": "**.test_run_uses_parent_context**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -842,8 +852,8 @@
 			],
 			"Summary": ""
 		},
-		"test_multiple_wildcard_patterns()": {
-			"Syntax": "**.test_multiple_wildcard_patterns**( *t* : cs.Testing.Testing )",
+		"test_run_executes_subtest()": {
+			"Syntax": "**.test_run_executes_subtest**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -853,8 +863,8 @@
 			],
 			"Summary": ""
 		},
-		"test_special_characters_in_patterns()": {
-			"Syntax": "**.test_special_characters_in_patterns**( *t* : cs.Testing.Testing )",
+		"test_fail_after_fatal()": {
+			"Syntax": "**.test_fail_after_fatal**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -864,8 +874,8 @@
 			],
 			"Summary": ""
 		},
-		"test_suite_filtering_logic()": {
-			"Syntax": "**.test_suite_filtering_logic**( *t* : cs.Testing.Testing )",
+		"test_multiple_fail_calls()": {
+			"Syntax": "**.test_multiple_fail_calls**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -875,8 +885,8 @@
 			],
 			"Summary": ""
 		},
-		"test_case_sensitivity()": {
-			"Syntax": "**.test_case_sensitivity**( *t* : cs.Testing.Testing )",
+		"test_state_persistence()": {
+			"Syntax": "**.test_state_persistence**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -886,8 +896,8 @@
 			],
 			"Summary": ""
 		},
-		"test_empty_pattern_handling()": {
-			"Syntax": "**.test_empty_pattern_handling**( *t* : cs.Testing.Testing )",
+		"test_run_with_data_argument()": {
+			"Syntax": "**.test_run_with_data_argument**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -897,8 +907,8 @@
 			],
 			"Summary": ""
 		},
-		"test_pattern_parsing_logic()": {
-			"Syntax": "**.test_pattern_parsing_logic**( *t* : cs.Testing.Testing )",
+		"test_log_empty_messages()": {
+			"Syntax": "**.test_log_empty_messages**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -908,8 +918,8 @@
 			],
 			"Summary": ""
 		},
-		"test_parameter_validation()": {
-			"Syntax": "**.test_parameter_validation**( *t* : cs.Testing.Testing )",
+		"test_run_propagates_failure()": {
+			"Syntax": "**.test_run_propagates_failure**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -919,8 +929,8 @@
 			],
 			"Summary": ""
 		},
-		"test_parse_single_parameter()": {
-			"Syntax": "**.test_parse_single_parameter**( *t* : cs.Testing.Testing )",
+		"test_run_propagates_assertions()": {
+			"Syntax": "**.test_run_propagates_assertions**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -929,87 +939,60 @@
 				]
 			],
 			"Summary": ""
-		}
-	},
-	"UnitStatsDetail": {
-		"getXCallParamLength()": {
-			"Syntax": "**.getXCallParamLength**( *xCall* : Integer ) : Integer",
-			"Params": [
-				[
-					"xCall",
-					"Integer",
-					"->"
-				],
-				[
-					"",
-					"Integer",
-					"<-"
-				]
-			],
-			"Summary": ""
 		},
-		"getXCallYParameter()": {
-			"Syntax": "**.getXCallYParameter**( *xCall* : Integer; *yParam* : Integer ) : Variant",
+		"test_fatal_method()": {
+			"Syntax": "**.test_fatal_method**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
-					"xCall",
-					"Integer",
-					"->"
-				],
-				[
-					"yParam",
-					"Integer",
-					"->"
-				],
-				[
-					"",
-					"Variant",
-					"<-"
-				]
-			],
-			"Summary": ""
-		},
-		"getNumberOfCalls()": {
-			"Syntax": "**.getNumberOfCalls**() : Integer",
-			"Params": [
-				[
-					"",
-					"Integer",
-					"<-"
-				]
-			],
-			"Summary": ""
-		},
-		"appendCalledParameters()": {
-			"Syntax": "**.appendCalledParameters**( *parameters* : Collection )",
-			"Params": [
-				[
-					"parameters",
-					"Collection",
+					"t",
+					"cs.Testing.Testing",
 					"->"
 				]
 			],
 			"Summary": ""
 		},
-		"getXCallParams()": {
-			"Syntax": "**.getXCallParams**( *xCall* : Integer ) : Collection",
+		"test_fail_method()": {
+			"Syntax": "**.test_fail_method**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
-					"xCall",
-					"Integer",
+					"t",
+					"cs.Testing.Testing",
 					"->"
-				],
-				[
-					"",
-					"Collection",
-					"<-"
 				]
 			],
 			"Summary": ""
 		},
-		"reset()": {
-			"Syntax": "**.reset**()",
-			"Params": [],
+		"test_testing_initialization()": {
+			"Syntax": "**.test_testing_initialization**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_log_message_collection()": {
+			"Syntax": "**.test_log_message_collection**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_log_with_special_characters()": {
+			"Syntax": "**.test_log_with_special_characters**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
 			"Summary": ""
 		}
 	},
@@ -1206,9 +1189,9 @@
 			"Summary": ""
 		}
 	},
-	"_TestingTest": {
-		"test_run_subtest_stats_isolated()": {
-			"Syntax": "**.test_run_subtest_stats_isolated**( *t* : cs.Testing.Testing )",
+	"_ParameterParsingTest": {
+		"test_edge_case_patterns()": {
+			"Syntax": "**.test_edge_case_patterns**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -1218,8 +1201,8 @@
 			],
 			"Summary": ""
 		},
-		"test_run_uses_parent_context()": {
-			"Syntax": "**.test_run_uses_parent_context**( *t* : cs.Testing.Testing )",
+		"test_wildcard_suite_filtering()": {
+			"Syntax": "**.test_wildcard_suite_filtering**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -1229,8 +1212,8 @@
 			],
 			"Summary": ""
 		},
-		"test_run_executes_subtest()": {
-			"Syntax": "**.test_run_executes_subtest**( *t* : cs.Testing.Testing )",
+		"test_multiple_wildcard_patterns()": {
+			"Syntax": "**.test_multiple_wildcard_patterns**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -1240,8 +1223,8 @@
 			],
 			"Summary": ""
 		},
-		"test_fail_after_fatal()": {
-			"Syntax": "**.test_fail_after_fatal**( *t* : cs.Testing.Testing )",
+		"test_special_characters_in_patterns()": {
+			"Syntax": "**.test_special_characters_in_patterns**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -1251,8 +1234,8 @@
 			],
 			"Summary": ""
 		},
-		"test_multiple_fail_calls()": {
-			"Syntax": "**.test_multiple_fail_calls**( *t* : cs.Testing.Testing )",
+		"test_suite_filtering_logic()": {
+			"Syntax": "**.test_suite_filtering_logic**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -1262,8 +1245,8 @@
 			],
 			"Summary": ""
 		},
-		"test_state_persistence()": {
-			"Syntax": "**.test_state_persistence**( *t* : cs.Testing.Testing )",
+		"test_case_sensitivity()": {
+			"Syntax": "**.test_case_sensitivity**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -1273,8 +1256,8 @@
 			],
 			"Summary": ""
 		},
-		"test_run_with_data_argument()": {
-			"Syntax": "**.test_run_with_data_argument**( *t* : cs.Testing.Testing )",
+		"test_empty_pattern_handling()": {
+			"Syntax": "**.test_empty_pattern_handling**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -1284,8 +1267,8 @@
 			],
 			"Summary": ""
 		},
-		"test_log_empty_messages()": {
-			"Syntax": "**.test_log_empty_messages**( *t* : cs.Testing.Testing )",
+		"test_pattern_parsing_logic()": {
+			"Syntax": "**.test_pattern_parsing_logic**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -1295,8 +1278,8 @@
 			],
 			"Summary": ""
 		},
-		"test_run_propagates_failure()": {
-			"Syntax": "**.test_run_propagates_failure**( *t* : cs.Testing.Testing )",
+		"test_parameter_validation()": {
+			"Syntax": "**.test_parameter_validation**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -1306,63 +1289,8 @@
 			],
 			"Summary": ""
 		},
-		"test_run_propagates_assertions()": {
-			"Syntax": "**.test_run_propagates_assertions**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		},
-		"test_fatal_method()": {
-			"Syntax": "**.test_fatal_method**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		},
-		"test_fail_method()": {
-			"Syntax": "**.test_fail_method**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		},
-		"test_testing_initialization()": {
-			"Syntax": "**.test_testing_initialization**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		},
-		"test_log_message_collection()": {
-			"Syntax": "**.test_log_message_collection**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		},
-		"test_log_with_special_characters()": {
-			"Syntax": "**.test_log_with_special_characters**( *t* : cs.Testing.Testing )",
+		"test_parse_single_parameter()": {
+			"Syntax": "**.test_parse_single_parameter**( *t* : cs.Testing.Testing )",
 			"Params": [
 				[
 					"t",
@@ -1522,6 +1450,12 @@
 				]
 			],
 			"Summary": ""
+		},
+		"testClassName": {
+			"Syntax": "testClassName : Text"
+		},
+		"testFunctionName": {
+			"Syntax": "testFunctionName : Text"
 		},
 		"failureCallChain": {
 			"Syntax": "failureCallChain : Collection"
@@ -1982,131 +1916,6 @@
 			"Syntax": "class : 4D.Class"
 		}
 	},
-	"_TransactionDebugTest": {
-		"test_basicStartTransaction()": {
-			"Syntax": "**.test_basicStartTransaction**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		},
-		"test_basicInTransaction()": {
-			"Syntax": "**.test_basicInTransaction**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		}
-	},
-	"TriggerConfigurationTest": {
-		"test_storageInitializedWithTriggersEnabled()": {
-			"Syntax": "**.test_storageInitializedWithTriggersEnabled**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		},
-		"test_defaultTriggerBehavior()": {
-			"Syntax": "**.test_defaultTriggerBehavior**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		},
-		"test_triggerControlParsing_enabled()": {
-			"Syntax": "**.test_triggerControlParsing_enabled**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		},
-		"test_storageInitializedWithDefaultBehavior()": {
-			"Syntax": "**.test_storageInitializedWithDefaultBehavior**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		},
-		"test_triggersDisabledParameter()": {
-			"Syntax": "**.test_triggersDisabledParameter**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		},
-		"test_triggersEnabledParameter()": {
-			"Syntax": "**.test_triggersEnabledParameter**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		},
-		"test_restoreDefaultTriggerBehavior()": {
-			"Syntax": "**.test_restoreDefaultTriggerBehavior**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		},
-		"test_triggerControlParsing_disabled()": {
-			"Syntax": "**.test_triggerControlParsing_disabled**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		},
-		"test_triggerControlParsing_default()": {
-			"Syntax": "**.test_triggerControlParsing_default**( *t* : cs.Testing.Testing )",
-			"Params": [
-				[
-					"t",
-					"cs.Testing.Testing",
-					"->"
-				]
-			],
-			"Summary": ""
-		}
-	},
 	"_SimpleTransactionTest": {
 		"test_disableTransaction()": {
 			"Syntax": "**.test_disableTransaction**( *t* : cs.Testing.Testing )",
@@ -2210,6 +2019,37 @@
 				[
 					"message",
 					"Text",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"areDeepEqual()": {
+			"Syntax": "**.areDeepEqual**( *t* : Object; *expected* : Variant; *actual* : Variant; *message* : Text; *maxDepth* : Integer )",
+			"Params": [
+				[
+					"t",
+					"Object",
+					"->"
+				],
+				[
+					"expected",
+					"Variant",
+					"->"
+				],
+				[
+					"actual",
+					"Variant",
+					"->"
+				],
+				[
+					"message",
+					"Text",
+					"->"
+				],
+				[
+					"maxDepth",
+					"Integer",
 					"->"
 				]
 			],
@@ -2417,6 +2257,470 @@
 			"Summary": ""
 		}
 	},
+	"_AssertDeepEqualTest": {
+		"test_areDeepEqual_max_depth_mixed_nesting()": {
+			"Syntax": "**.test_areDeepEqual_max_depth_mixed_nesting**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_max_depth_collection_nesting()": {
+			"Syntax": "**.test_areDeepEqual_max_depth_collection_nesting**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_max_depth_clears_stale_differences()": {
+			"Syntax": "**.test_areDeepEqual_max_depth_clears_stale_differences**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_max_depth_increased_detects_deep_difference()": {
+			"Syntax": "**.test_areDeepEqual_max_depth_increased_detects_deep_difference**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_max_depth_custom_limit()": {
+			"Syntax": "**.test_areDeepEqual_max_depth_custom_limit**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_max_depth_within_limit()": {
+			"Syntax": "**.test_areDeepEqual_max_depth_within_limit**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_max_depth_exceeds_fails()": {
+			"Syntax": "**.test_areDeepEqual_max_depth_exceeds_fails**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_collections_with_null_elements()": {
+			"Syntax": "**.test_areDeepEqual_collections_with_null_elements**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_objects_with_null_properties()": {
+			"Syntax": "**.test_areDeepEqual_objects_with_null_properties**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_max_depth_detects_difference_within_limit()": {
+			"Syntax": "**.test_areDeepEqual_max_depth_detects_difference_within_limit**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_different_types()": {
+			"Syntax": "**.test_areDeepEqual_different_types**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_empty_vs_non_empty_object()": {
+			"Syntax": "**.test_areDeepEqual_empty_vs_non_empty_object**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_empty_objects()": {
+			"Syntax": "**.test_areDeepEqual_empty_objects**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_null_vs_collection()": {
+			"Syntax": "**.test_areDeepEqual_null_vs_collection**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_complex_circular_reference()": {
+			"Syntax": "**.test_areDeepEqual_complex_circular_reference**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_simple_collections_different_values()": {
+			"Syntax": "**.test_areDeepEqual_simple_collections_different_values**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_null_collections()": {
+			"Syntax": "**.test_areDeepEqual_null_collections**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_max_depth_exceeded_at_11()": {
+			"Syntax": "**.test_areDeepEqual_max_depth_exceeded_at_11**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_mixed_nested_collections_with_objects()": {
+			"Syntax": "**.test_areDeepEqual_mixed_nested_collections_with_objects**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_circular_reference_objects()": {
+			"Syntax": "**.test_areDeepEqual_circular_reference_objects**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_deeply_nested_structures()": {
+			"Syntax": "**.test_areDeepEqual_deeply_nested_structures**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_nested_objects_different()": {
+			"Syntax": "**.test_areDeepEqual_nested_objects_different**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_null_vs_object()": {
+			"Syntax": "**.test_areDeepEqual_null_vs_object**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_primitives_equal()": {
+			"Syntax": "**.test_areDeepEqual_primitives_equal**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_empty_collections()": {
+			"Syntax": "**.test_areDeepEqual_empty_collections**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_max_depth_very_deep_nesting()": {
+			"Syntax": "**.test_areDeepEqual_max_depth_very_deep_nesting**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_empty_vs_non_empty_collection()": {
+			"Syntax": "**.test_areDeepEqual_empty_vs_non_empty_collection**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_mixed_nested_objects_with_collections()": {
+			"Syntax": "**.test_areDeepEqual_mixed_nested_objects_with_collections**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_primitives_different()": {
+			"Syntax": "**.test_areDeepEqual_primitives_different**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_nested_collections_different()": {
+			"Syntax": "**.test_areDeepEqual_nested_collections_different**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_simple_objects_equal()": {
+			"Syntax": "**.test_areDeepEqual_simple_objects_equal**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_nested_objects_equal()": {
+			"Syntax": "**.test_areDeepEqual_nested_objects_equal**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_user_reported_scenario()": {
+			"Syntax": "**.test_areDeepEqual_user_reported_scenario**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_complex_real_world_structure()": {
+			"Syntax": "**.test_areDeepEqual_complex_real_world_structure**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_null_objects()": {
+			"Syntax": "**.test_areDeepEqual_null_objects**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_simple_collections_different_lengths()": {
+			"Syntax": "**.test_areDeepEqual_simple_collections_different_lengths**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_circular_reference_collections()": {
+			"Syntax": "**.test_areDeepEqual_circular_reference_collections**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_simple_objects_different_values()": {
+			"Syntax": "**.test_areDeepEqual_simple_objects_different_values**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_object_with_undefined_properties()": {
+			"Syntax": "**.test_areDeepEqual_object_with_undefined_properties**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_nested_collections_equal()": {
+			"Syntax": "**.test_areDeepEqual_nested_collections_equal**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_simple_collections_equal()": {
+			"Syntax": "**.test_areDeepEqual_simple_collections_equal**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_areDeepEqual_simple_objects_different_keys()": {
+			"Syntax": "**.test_areDeepEqual_simple_objects_different_keys**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		}
+	},
 	"_ErrorHandlingTest": {
 		"test_assertion_failure_handling()": {
 			"Syntax": "**.test_assertion_failure_handling**( *t* : cs.Testing.Testing )",
@@ -2493,6 +2797,88 @@
 					"->"
 				]
 			],
+			"Summary": ""
+		}
+	},
+	"UnitStatsDetail": {
+		"getXCallParamLength()": {
+			"Syntax": "**.getXCallParamLength**( *xCall* : Integer ) : Integer",
+			"Params": [
+				[
+					"xCall",
+					"Integer",
+					"->"
+				],
+				[
+					"",
+					"Integer",
+					"<-"
+				]
+			],
+			"Summary": ""
+		},
+		"getXCallYParameter()": {
+			"Syntax": "**.getXCallYParameter**( *xCall* : Integer; *yParam* : Integer ) : Variant",
+			"Params": [
+				[
+					"xCall",
+					"Integer",
+					"->"
+				],
+				[
+					"yParam",
+					"Integer",
+					"->"
+				],
+				[
+					"",
+					"Variant",
+					"<-"
+				]
+			],
+			"Summary": ""
+		},
+		"getNumberOfCalls()": {
+			"Syntax": "**.getNumberOfCalls**() : Integer",
+			"Params": [
+				[
+					"",
+					"Integer",
+					"<-"
+				]
+			],
+			"Summary": ""
+		},
+		"appendCalledParameters()": {
+			"Syntax": "**.appendCalledParameters**( *parameters* : Collection )",
+			"Params": [
+				[
+					"parameters",
+					"Collection",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"getXCallParams()": {
+			"Syntax": "**.getXCallParams**( *xCall* : Integer ) : Collection",
+			"Params": [
+				[
+					"xCall",
+					"Integer",
+					"->"
+				],
+				[
+					"",
+					"Collection",
+					"<-"
+				]
+			],
+			"Summary": ""
+		},
+		"reset()": {
+			"Syntax": "**.reset**()",
+			"Params": [],
 			"Summary": ""
 		}
 	},
@@ -2914,6 +3300,131 @@
 		},
 		"class": {
 			"Syntax": "class : 4D.Class"
+		}
+	},
+	"TriggerConfigurationTest": {
+		"test_storageInitializedWithTriggersEnabled()": {
+			"Syntax": "**.test_storageInitializedWithTriggersEnabled**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_defaultTriggerBehavior()": {
+			"Syntax": "**.test_defaultTriggerBehavior**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_triggerControlParsing_enabled()": {
+			"Syntax": "**.test_triggerControlParsing_enabled**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_storageInitializedWithDefaultBehavior()": {
+			"Syntax": "**.test_storageInitializedWithDefaultBehavior**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_triggersDisabledParameter()": {
+			"Syntax": "**.test_triggersDisabledParameter**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_triggersEnabledParameter()": {
+			"Syntax": "**.test_triggersEnabledParameter**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_restoreDefaultTriggerBehavior()": {
+			"Syntax": "**.test_restoreDefaultTriggerBehavior**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_triggerControlParsing_disabled()": {
+			"Syntax": "**.test_triggerControlParsing_disabled**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_triggerControlParsing_default()": {
+			"Syntax": "**.test_triggerControlParsing_default**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		}
+	},
+	"_TransactionDebugTest": {
+		"test_basicStartTransaction()": {
+			"Syntax": "**.test_basicStartTransaction**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
+		},
+		"test_basicInTransaction()": {
+			"Syntax": "**.test_basicInTransaction**( *t* : cs.Testing.Testing )",
+			"Params": [
+				[
+					"t",
+					"cs.Testing.Testing",
+					"->"
+				]
+			],
+			"Summary": ""
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Runtime errors no longer crash the test runner.** Errors raised by `ON ERR CALL` during a test are captured, attached to the offending test as a structured `runtimeErrors[]` entry plus a synthetic failed assertion with `isRuntimeError: true`, and the remaining tests still run.
- **Reports are always produced.** `_generateReport()` is invoked from `run()` (was buried inside `_runSuitesSequentially`) so the report still renders after global error capture, even when execution is bumpy.
- **Host/component error boundary solved.** A 4D component's `ON ERR CALL` cannot catch errors raised in host scope. The component now reads `$hostStorage.testErrors` so a host that installs its own `TestErrorHandler` / `TestGlobalErrorHandler` and shares its `Storage` can route host-side errors into the per-test and global pipelines (`runtimeErrors[]` per test, `globalErrors[]` / `<system-err>` for the rest).
- **JUnit XML correctness.** Precise `failures` / `errors` / `skipped` counts on `<testsuites>` and `<testsuite>`; valid ISO 8601 `timestamp` (was producing `…T00:00:00ZT16:47:10`); `<skipped/>` child on every skipped `<testcase>` so consumers (Jenkins, JUnitXML, GitLab) classify them correctly. External runtime errors live in a `<system-err>` block instead of inflating `errors` and driving `failures` negative.
- **New CLI flags.** `outputPath=` writes JSON or JUnit reports to disk (sidesteps any debug noise on stdout); `callchain=true` adds `callChain` to terse-JSON failures without going full verbose. Both flow through every Makefile target.
- **Per-test enrichment.** Every assertion record now carries `line` and `functionName` (qualified `Class.method`) when the call chain has the test frame; runtime errors are mirrored into `runtimeErrors[]` with `functionName` and `formula`; captured errors include a `callChainJSON` snapshot taken at the moment the error fired.
- **Docs.** `README`, `docs/guide.md`, `AGENTS`, `CLAUDE`, and `AI_AGENT_TESTING_GUIDE` updated for the new flags, refreshed JSON / JUnit samples, the captured-error schema, and the host-integration wiring.

### Changes

| File | What changed |
|------|-------------|
| `.gitignore` | Ignore local dev artifacts (`Components/`, `testing/Logs/`, `testing/test-results/`, `testing/*.4DD`, `testing/*.Match`, `Makefile.local`, `.DS_Store`) |
| `Makefile` | Forward `outputPath` / `verbose` / `callchain` to `--user-param`. Reroute every secondary target (`test-junit`, `test-ci`, `test-parallel*`, etc.) through `$(MAKE) test …` so all flags compose consistently. |
| `testing/Project/Sources/Classes/Testing.4dm` | New `testFunctionName` / `testClassName` properties (initialized in the constructor, reset in `resetForNewTest`) so reports can attribute assertions and errors to a qualified test name. |
| `testing/Project/Sources/Classes/Assert.4dm` | `_recordAssertion` now records `line` and `functionName` when the call chain contains the test frame; new `_findTestLine($t; $callChain)` helper walks the chain looking for that frame. |
| `testing/Project/Sources/Classes/_TestFunction.4dm` | After running each test, drains errors from both component `Storage.testErrors` and host `$hostStorage.testErrors` (matched by `processNumber`); each error gets `functionName` / `formula` and a synthetic failed assertion via new `_addRuntimeErrorAsAssertion`; `failureCallChain` populated from `error.callChainJSON`; new `_getHostStorage` helper; `_errorBelongsToProcess` no longer falls back to `True` for unowned errors. Transaction cleanup simplified. |
| `testing/Project/Sources/Classes/TestRunner.4dm` | `_generateReport()` moved into `run()` so it runs after global error capture; new `callChainOutput` property gates terse-JSON `callChain` (`verbose=true` OR `callchain=true`); preps and drains `hostStorage.testErrors` (init + global drain); JSON terse mode emits per-test `runtimeErrors[]` and honors `outputPath=` via new `_writeJSONToFile`; JUnit fix: accurate `failures` / `errors` / `skipped` counts on `<testsuites>` and `<testsuite>`, `<skipped/>` child for skipped cases, valid ISO 8601 timestamp; shared `_resolveOutputFile` handles relative + absolute (POSIX / Windows) paths; human-mode call chains now gated on `verbose=true`. |
| `testing/Project/Sources/Methods/TestErrorHandler.4dm` | Captures `Last errors[0].message` for the human-readable `message` field; captures `Get call chain` immediately and stores it as `callChainJSON` on the error record; chain filter only drops the handler frame itself (preserves test-method frames in the `testing` database). |
| `testing/Project/Sources/Methods/TestGlobalErrorHandler.4dm` | Same enhancements as `TestErrorHandler`. |
| `testing/Resources/en.lproj/syntaxEN.json` | Auto-regenerated for the new public surface (properties, methods, parameters). |
| `README.md`, `AGENTS.md`, `CLAUDE.md`, `AI_AGENT_TESTING_GUIDE.md`, `docs/guide.md` | Document the new flags, refreshed JSON / JUnit samples, the captured-error schema, and the host-integration wiring example. |

## Test plan

### Prerequisites
- Checkout the symphony branch `HRS/SWE-44545-error-handling-test`
- Copy the built `Testing.4dbase` component into your symphony `Components/` folder

### Steps

1. **Baseline — full suite passes across all three output formats**
   ```bash
   make test                                                          # human, exit 0
   make test format=json outputPath=test-results/report.json          # JSON to file
   make test-ci                                                        # JUnit XML -> test-results/junit.xml
   ```
   All three exit `0`. Confirm:
   - `test-results/report.json` is a single valid JSON document containing `tests`, `passed`, `failed`, `skipped`, **plus `globalErrorCount` and `globalErrors`** — these fields are the host-error pathway showing it's wired (typically `0` / `[]` when symphony is healthy).
   - `test-results/junit.xml` opens with `<testsuites tests="N" failures="0" errors="0" skipped="M" time="…" timestamp="YYYY-MM-DDTHH:MM:SS">`. The `timestamp` is a valid ISO 8601 (no `Z`, no doubled `T…`). Each skipped `<testcase>` contains a `<skipped/>` child. A `<system-err>` block is present (empty when no host errors fired, populated when they did).

2. **Per-test runtime error — captured, reported, non-fatal**
   In `UpdateSOLocationTest.test_empty_updates_collection`, add `ALERT($result.length)` as the first line of the body (forces `[8] Alphanumeric argument expected`), then:
   ```bash
   make test format=json test=UpdateSOLocationTest outputPath=/tmp/r.json
   ```
   In `/tmp/r.json`:
   - `"tests": 13, "passed": 12, "failed": 1, "status": "fail"` — the runner did **not** crash, the report was still written, and the other 12 tests still ran.
   - The failed test's `assertions[]` contains a synthetic entry with `isRuntimeError: true`, `actual: "[8] An Alphanumeric argument was expected."`, `line: 3`, `functionName: "UpdateSOLocationTest.test_empty_updates_collection"`.
   - The failed test's `runtimeErrors[]` contains `code: 8`, `message: "An Alphanumeric argument was expected."`, `formula: "ALERT($result.length)"`.

3. **`callchain=true` enriches terse JSON without going full verbose**
   With the broken test still in place:
   ```bash
   make test format=json test=UpdateSOLocationTest callchain=true outputPath=/tmp/r-cc.json
   ```
   In `/tmp/r-cc.json`, the `failures[]` entry for `test_empty_updates_collection` now carries a `callChain` collection containing the test-method frame (and surrounding stack). Re-running without `callchain=true` confirms it disappears — terse stays terse by default.

4. **Host-side capture proves the component/host boundary** *(optional but the headline feature)*
   Move the `ALERT` out of the test method into a tiny host helper:
   ```4d
   // _HostErrorHelper.4dm  (host project)
   var $obj : Object
   ALERT($obj.length)
   ```
   Call `_HostErrorHelper()` from the test in place of the inline `ALERT`. Re-run the step 2 command. The runtime error still surfaces on the test with the same `runtimeErrors[]` shape — but this time the error fired in **host** scope, where the component's own `ON ERR CALL` cannot reach. It only reaches the report because the host's `TestErrorHandler` pushed it onto `Storage.testErrors`, which the component drained via `$hostStorage.testErrors`.

5. **Cleanup** — Revert the `ALERT` change(s) and delete `_HostErrorHelper` if you added it. `make test` returns all green.

Made with [Cursor](https://cursor.com)