### PR TITLE
Move summary to end of human report output

### DIFF
--- a/testing/Project/Sources/Classes/TestRunner.4dm
+++ b/testing/Project/Sources/Classes/TestRunner.4dm
@@ -442,19 +442,15 @@ Function _generateHumanReport()
 		$passRate:=0
 	End if 
 	
-	LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "=== Test Results Summary ===\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "Total Tests: "+String:C10(This:C1470.results.totalTests)+"\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "Passed: "+String:C10(This:C1470.results.passed)+"\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "Failed: "+String:C10(This:C1470.results.failed)+"\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "Skipped: "+String:C10(This:C1470.results.skipped)+"\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "Assertions: "+String:C10(This:C1470.results.assertions)+"\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "Pass Rate: "+String:C10($passRate; "##0.0")+"%\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "Duration: "+String:C10(This:C1470.results.duration)+"ms\r\n"; Information message:K38:1)
-	
-	var $externalMessageType : Integer
-	$externalMessageType:=Choose:C955(This:C1470.results.globalErrorCount>0; Error message:K38:3; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "External Errors: "+String:C10(This:C1470.results.globalErrorCount)+"\r\n"; $externalMessageType)
+	If (This:C1470.results.hasGlobalErrors)
+		LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
+		LOG EVENT:C667(Into system standard outputs:K38:9; "=== Runtime Errors Outside Test Processes ===\r\n"; Error message:K38:3)
+		
+		var $globalError : Object
+		For each ($globalError; This:C1470.results.globalErrors)
+			LOG EVENT:C667(Into system standard outputs:K38:9; This:C1470._formatGlobalErrorForLog($globalError)+"\r\n"; Error message:K38:3)
+		End for each 
+	End if 
 	
 	If (This:C1470.results.failed>0)
 		LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
@@ -481,15 +477,19 @@ Function _generateHumanReport()
 		End for each 
 	End if 
 	
-	If (This:C1470.results.hasGlobalErrors)
-		LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
-		LOG EVENT:C667(Into system standard outputs:K38:9; "=== Runtime Errors Outside Test Processes ===\r\n"; Error message:K38:3)
-		
-		var $globalError : Object
-		For each ($globalError; This:C1470.results.globalErrors)
-			LOG EVENT:C667(Into system standard outputs:K38:9; This:C1470._formatGlobalErrorForLog($globalError)+"\r\n"; Error message:K38:3)
-		End for each 
-	End if 
+	LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "=== Test Results Summary ===\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "Total Tests: "+String:C10(This:C1470.results.totalTests)+"\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "Passed: "+String:C10(This:C1470.results.passed)+"\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "Failed: "+String:C10(This:C1470.results.failed)+"\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "Skipped: "+String:C10(This:C1470.results.skipped)+"\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "Assertions: "+String:C10(This:C1470.results.assertions)+"\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "Pass Rate: "+String:C10($passRate; "##0.0")+"%\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "Duration: "+String:C10(This:C1470.results.duration)+"ms\r\n"; Information message:K38:1)
+	
+	var $externalMessageType : Integer
+	$externalMessageType:=Choose:C955(This:C1470.results.globalErrorCount>0; Error message:K38:3; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "External Errors: "+String:C10(This:C1470.results.globalErrorCount)+"\r\n"; $externalMessageType)
 	
 	This:C1470._logFooter()
 	


### PR DESCRIPTION
## Summary
- Reorders the human-readable test report so external errors and failed tests print before the summary section
- The summary (totals, pass rate, duration, external error count) is now always the last section in the output, making it easy to find at a glance

## Test plan
- [x] All 208 tests pass in the testing project
- [x] All 1200 tests pass in symphony (1197 passed, 3 skipped, 0 failed)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized test report output for improved readability. Runtime errors occurring outside test processes now appear before the failed tests section when present. The test results summary, including pass rate, duration metrics, and external error count, now displays after failed tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KyleKincer/testing/pull/31)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->