### PR TITLE
feat: streamlined output, failure detection, and call chain support for external errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,9 @@ This project provides a complete testing framework for 4D applications featuring
 make test
 
 # Pass parameters directly to test command
-make test format=json
+make test format=json outputPath=test-results/report.json
 make test tags=unit
-make test format=json tags=unit excludeTags=slow
+make test format=json outputPath=test-results/report.json tags=unit excludeTags=slow
 make test test=ExampleTest
 
 # Alternative named commands
@@ -72,11 +72,11 @@ If you need more control or the Makefile doesn't meet your needs:
 # Run all tests with human output
 /Applications/tool4d.app/Contents/MacOS/tool4d --project $(PWD)/testing/Project/testing.4DProject --skip-onstartup --dataless --startup-method "test"
 
-# Run all tests with JSON output  
-/Applications/tool4d.app/Contents/MacOS/tool4d --project $(PWD)/testing/Project/testing.4DProject --skip-onstartup --dataless --startup-method "test" --user-param "format=json"
+# Run all tests with JSON output (outputPath required)
+/Applications/tool4d.app/Contents/MacOS/tool4d --project $(PWD)/testing/Project/testing.4DProject --skip-onstartup --dataless --startup-method "test" --user-param "format=json outputPath=test-results/report.json"
 
-# Run all tests with JUnit XML output (saves to test-results/junit.xml)
-/Applications/tool4d.app/Contents/MacOS/tool4d --project $(PWD)/testing/Project/testing.4DProject --skip-onstartup --dataless --startup-method "test" --user-param "format=junit"
+# Run all tests with JUnit XML output (outputPath required)
+/Applications/tool4d.app/Contents/MacOS/tool4d --project $(PWD)/testing/Project/testing.4DProject --skip-onstartup --dataless --startup-method "test" --user-param "format=junit outputPath=test-results/junit.xml"
 ```
 
 ### Linux setup notes
@@ -100,21 +100,29 @@ If you need more control or the Makefile doesn't meet your needs:
 
 # Combined filtering
 --user-param "tags=unit excludeTags=slow"
---user-param "format=json tags=integration"
---user-param "format=junit tags=unit"
---user-param "format=junit outputPath=results/junit.xml"
+--user-param "format=json outputPath=test-results/report.json tags=integration"
+--user-param "format=junit outputPath=results/junit.xml tags=unit"
 
-# JSON / JUnit file output (writes report to disk)
+# JSON / JUnit file output (outputPath is REQUIRED for format=json and format=junit)
+# Human-readable output always streams to stdout regardless of format
 --user-param "format=json outputPath=test-results/report.json"
+--user-param "format=junit outputPath=test-results/junit.xml"
 
 # Include callChain on failed tests in terse JSON without going full verbose
---user-param "format=json callchain=true"
+--user-param "format=json outputPath=test-results/report.json callchain=true"
 
 # Parallel execution
 --user-param "parallel=true"
 --user-param "parallel=true maxWorkers=4"
---user-param "parallel=true format=json tags=unit"
+--user-param "parallel=true format=json outputPath=test-results/report.json tags=unit"
 ```
+
+### Output Behavior
+
+- **Human-readable output always streams to stdout** regardless of format parameter
+- **format=json and format=junit require `outputPath`** -- these write to file only, never stdout
+- If `format=json` or `format=junit` is specified without `outputPath`, the framework prints an error and falls back to human-only output
+- **Exit code**: `make test` exits non-zero (exit 1) when any tests fail OR external runtime errors are detected
 
 ### Current Test Status
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,9 @@ make test-parallel-json     # Run tests in parallel with JSON output
 make test-parallel-unit     # Run unit tests in parallel
 make test-parallel-workers WORKERS=4  # Run with custom worker count
 
+# Debugging tool4d output (stderr is suppressed by default)
+make test debug=true        # Show tool4d diagnostic stderr
+
 # Show all available commands
 make help
 ```
@@ -101,7 +104,7 @@ If you need more control or the Makefile doesn't meet your needs:
 --user-param "format=junit tags=unit"
 --user-param "format=junit outputPath=results/junit.xml"
 
-# JSON / JUnit file output (clean, sidesteps any debug noise on stdout)
+# JSON / JUnit file output (writes report to disk)
 --user-param "format=json outputPath=test-results/report.json"
 
 # Include callChain on failed tests in terse JSON without going full verbose

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,9 @@ make test-parallel-json     # Run tests in parallel with JSON output
 make test-parallel-unit     # Run unit tests in parallel
 make test-parallel-workers WORKERS=4  # Run with custom worker count
 
+# Debugging tool4d output (stderr is suppressed by default)
+make test debug=true        # Show tool4d diagnostic stderr
+
 # Show all available commands
 make help
 ```
@@ -95,7 +98,7 @@ If you need more control or the Makefile doesn't meet your needs:
 --user-param "format=junit tags=unit"
 --user-param "format=junit outputPath=results/junit.xml"
 
-# JSON / JUnit file output (clean, sidesteps any debug noise on stdout)
+# JSON / JUnit file output (writes report to disk)
 --user-param "format=json outputPath=test-results/report.json"
 
 # Include callChain on failed tests in terse JSON without going full verbose

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,9 @@ This project provides a complete testing framework for 4D applications featuring
 make test
 
 # Pass parameters directly to test command
-make test format=json
+make test format=json outputPath=test-results/report.json
 make test tags=unit
-make test format=json tags=unit excludeTags=slow
+make test format=json outputPath=test-results/report.json tags=unit excludeTags=slow
 make test test=ExampleTest
 
 # Alternative named commands
@@ -73,11 +73,11 @@ If you need more control or the Makefile doesn't meet your needs:
 # Run all tests with human output
 /Applications/tool4d.app/Contents/MacOS/tool4d --project $(PWD)/testing/Project/testing.4DProject --skip-onstartup --dataless --startup-method "test"
 
-# Run all tests with JSON output  
-/Applications/tool4d.app/Contents/MacOS/tool4d --project $(PWD)/testing/Project/testing.4DProject --skip-onstartup --dataless --startup-method "test" --user-param "format=json"
+# Run all tests with JSON output (outputPath required)
+/Applications/tool4d.app/Contents/MacOS/tool4d --project $(PWD)/testing/Project/testing.4DProject --skip-onstartup --dataless --startup-method "test" --user-param "format=json outputPath=test-results/report.json"
 
-# Run all tests with JUnit XML output (saves to test-results/junit.xml)
-/Applications/tool4d.app/Contents/MacOS/tool4d --project $(PWD)/testing/Project/testing.4DProject --skip-onstartup --dataless --startup-method "test" --user-param "format=junit"
+# Run all tests with JUnit XML output (outputPath required, defaults to test-results/junit.xml)
+/Applications/tool4d.app/Contents/MacOS/tool4d --project $(PWD)/testing/Project/testing.4DProject --skip-onstartup --dataless --startup-method "test" --user-param "format=junit outputPath=test-results/junit.xml"
 ```
 
 ### Test Filtering Parameters
@@ -94,26 +94,34 @@ If you need more control or the Makefile doesn't meet your needs:
 
 # Combined filtering
 --user-param "tags=unit excludeTags=slow"
---user-param "format=json tags=integration"
---user-param "format=junit tags=unit"
---user-param "format=junit outputPath=results/junit.xml"
+--user-param "format=json outputPath=test-results/report.json tags=integration"
+--user-param "format=junit outputPath=results/junit.xml tags=unit"
 
-# JSON / JUnit file output (writes report to disk)
+# JSON / JUnit file output (outputPath is REQUIRED for format=json and format=junit)
+# Human-readable output always streams to stdout regardless of format
 --user-param "format=json outputPath=test-results/report.json"
+--user-param "format=junit outputPath=test-results/junit.xml"
 
 # Include callChain on failed tests in terse JSON without going full verbose
---user-param "format=json callchain=true"
+--user-param "format=json outputPath=test-results/report.json callchain=true"
 
 # Parallel execution
 --user-param "parallel=true"
 --user-param "parallel=true maxWorkers=4"
---user-param "parallel=true format=json tags=unit"
+--user-param "parallel=true format=json outputPath=test-results/report.json tags=unit"
 
 # Trigger control
 --user-param "triggers=enabled"   # Enable triggers for all tests
 --user-param "triggers=disabled"  # Disable triggers (default)
 --user-param "triggers=enabled tags=integration"  # Enable triggers for integration tests
 ```
+
+### Output Behavior
+
+- **Human-readable output always streams to stdout** regardless of format parameter
+- **format=json and format=junit require `outputPath`** -- these write to file only, never stdout
+- If `format=json` or `format=junit` is specified without `outputPath`, the framework prints an error and falls back to human-only output
+- **Exit code**: `make test` exits non-zero (exit 1) when any tests fail OR external runtime errors are detected. The framework writes an `error` file that the Makefile checks.
 
 ### Current Test Status
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # 4D Unit Testing Framework Makefile
+SHELL := /bin/bash
 
 # Get current user's home directory
 HOME_DIR := $(shell echo $$HOME)
@@ -35,7 +36,14 @@ EXCLUDE_TAGS_COMBINED := $(strip $(DEFAULT_EXCLUDE_TAGS) $(excludeTags))
 BASE_PARAMS := $(if $(EXCLUDE_TAGS_COMBINED),excludeTags=$(subst $(space),$(comma),$(EXCLUDE_TAGS_COMBINED)))
 
 # Build user parameters from make variables
-USER_PARAMS := $(strip $(BASE_PARAMS) $(if $(format),format=$(format)) $(if $(tags),tags=$(tags)) $(if $(test),test=$(test)) $(if $(requireTags),requireTags=$(requireTags)) $(if $(parallel),parallel=$(parallel)) $(if $(maxWorkers),maxWorkers=$(maxWorkers)) $(if $(outputPath),outputPath=$(outputPath)) $(if $(verbose),verbose=$(verbose)) $(if $(callchain),callchain=$(callchain)))
+USER_PARAMS := $(strip $(BASE_PARAMS) $(if $(format),format=$(format)) $(if $(tags),tags=$(tags)) $(if $(test),test=$(test)) $(if $(requireTags),requireTags=$(requireTags)) $(if $(parallel),parallel=$(parallel)) $(if $(maxWorkers),maxWorkers=$(maxWorkers)) $(if $(outputPath),outputPath=$(outputPath)) $(if $(verbose),verbose=$(verbose)) $(if $(callchain),callchain=$(callchain)) $(if $(triggers),triggers=$(triggers)))
+
+# Output filtering: suppress tool4d diagnostic noise by default.
+# - stderr redirected to /dev/null (tool4d.4DRT errors)
+# - stdout cooperative-yield warnings stripped via FIFO + grep
+# Pass debug=true to disable stderr suppression.
+STDERR_REDIRECT := $(if $(debug),,2>/dev/null)
+YIELD_FILTER := grep --line-buffered -v '^tool4d\.APPL Cooperative process doesn.t yield enough'
 
 # Ensure tool4d is installed (currently implemented for Linux only)
 $(TOOL4D):
@@ -57,11 +65,19 @@ $(TOOL4D):
 # Usage: make test [key=value key2=value2 ...]
 # Example: make test format=json tags=unit
 test: $(TOOL4D)
-	@if [ -n "$(USER_PARAMS)" ]; then \
-	        $(TOOL4D) $(BASE_OPTS) --user-param "$(USER_PARAMS)"; \
+	@fifo=$$(mktemp -u).fifo; mkfifo $$fifo; \
+	$(YIELD_FILTER) < $$fifo & filter_pid=$$!; \
+	if [ -n "$(USER_PARAMS)" ]; then \
+	        $(TOOL4D) $(BASE_OPTS) --user-param "$(USER_PARAMS)" $(STDERR_REDIRECT) > $$fifo & \
 	else \
-	        $(TOOL4D) $(BASE_OPTS); \
-	fi
+	        $(TOOL4D) $(BASE_OPTS) $(STDERR_REDIRECT) > $$fifo & \
+	fi; \
+	pid=$$!; \
+	trap 'disown $$pid $$filter_pid 2>/dev/null; kill -KILL $$pid $$filter_pid 2>/dev/null; rm -f $$fifo; exit 130' INT TERM; \
+	wait $$pid; ret=$$?; \
+	kill $$filter_pid 2>/dev/null; wait $$filter_pid 2>/dev/null; \
+	rm -f $$fifo; \
+	exit $$ret
 
 # Run all tests with JSON output
 test-json:
@@ -150,6 +166,9 @@ help:
 	@echo "  test-parallel-workers - Run tests in parallel with custom worker count"
 	@echo "  help                - Show this help message"
 	@echo ""
+	@echo "Options:"
+	@echo "  debug=true          - Show tool4d diagnostic stderr (suppressed by default)"
+	@echo ""
 	@echo "Examples:"
 	@echo "  make test"
 	@echo "  make test format=json"
@@ -167,6 +186,7 @@ help:
 	@echo "  make test-parallel-json"
 	@echo "  make test-parallel-workers WORKERS=4"
 	@echo "  make test parallel=true maxWorkers=6"
+	@echo "  make test debug=true              # Show tool4d stderr output"
 
 tool4d: $(TOOL4D)
 	@echo "tool4d ready at $(TOOL4D)"

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ TOOL4D_URL_LINUX := https://resources-download.4d.com/release/20%20Rx/latest/lat
 
 # Project path relative to current directory
 PROJECT_PATH := $(PWD)/testing/Project/testing.4DProject
+PROJECT_DIR := $(PWD)/testing/Project
+ERROR_FILE := $(PROJECT_DIR)/error
 
 # Base command options
 BASE_OPTS := --project $(PROJECT_PATH) --skip-onstartup --dataless --startup-method "test"
@@ -77,11 +79,12 @@ test: $(TOOL4D)
 	wait $$pid; ret=$$?; \
 	kill $$filter_pid 2>/dev/null; wait $$filter_pid 2>/dev/null; \
 	rm -f $$fifo; \
+	if [ -f "$(ERROR_FILE)" ]; then rm -f "$(ERROR_FILE)"; exit 1; fi; \
 	exit $$ret
 
 # Run all tests with JSON output
 test-json:
-	$(MAKE) test format=json
+	$(MAKE) test format=json outputPath=test-results/report.json
 
 # Run specific test class (usage: make test-class CLASS=ExampleTest)
 test-class:
@@ -109,11 +112,11 @@ test-integration:
 
 # Run tests with JSON output and unit tag
 test-unit-json:
-	$(MAKE) test format=json tags=unit
+	$(MAKE) test format=json outputPath=test-results/report.json tags=unit
 
 # Run all tests with JUnit XML output
 test-junit:
-	$(MAKE) test format=junit
+	$(MAKE) test format=junit outputPath=test-results/junit.xml
 
 # Run tests for CI/CD with custom output path
 test-ci:
@@ -121,11 +124,11 @@ test-ci:
 
 # Run unit tests with JUnit XML output
 test-unit-junit:
-	$(MAKE) test format=junit tags=unit
+	$(MAKE) test format=junit outputPath=test-results/junit.xml tags=unit
 
 # Run integration tests with JUnit XML output
 test-integration-junit:
-	$(MAKE) test format=junit tags=integration
+	$(MAKE) test format=junit outputPath=test-results/junit.xml tags=integration
 
 # Run tests in parallel mode
 test-parallel:
@@ -133,7 +136,7 @@ test-parallel:
 
 # Run tests in parallel mode with JSON output
 test-parallel-json:
-	$(MAKE) test parallel=true format=json
+	$(MAKE) test parallel=true format=json outputPath=test-results/report.json
 
 # Run unit tests in parallel mode
 test-parallel-unit:

--- a/testing/Project/Sources/Classes/ParallelTestRunner.4dm
+++ b/testing/Project/Sources/Classes/ParallelTestRunner.4dm
@@ -189,7 +189,7 @@ Function _waitForCompletionAndCollectResults()
 			
 			If ((Milliseconds:C459-$startWait)>$timeout)
 				// Timeout - log error and break
-				LOG EVENT:C667(Into system standard outputs:K38:9; "Parallel test execution timeout after 5 minutes\r\n"; Error message:K38:3)
+				LOG EVENT:C667(Into system standard outputs:K38:9; "Parallel test execution timeout after 5 minutes\r\n"; Information message:K38:1)
 				break
 			End if
 			
@@ -269,7 +269,7 @@ Function _processWorkerResults($suiteResults : Object)
                                                         End if
                                                 End if
 
-                                                LOG EVENT:C667(Into system standard outputs:K38:9; "  ✗ "+$test.name+" ("+String:C10($test.duration)+"ms)"+$errorDetails+"\r\n"; Error message:K38:3)
+                                                LOG EVENT:C667(Into system standard outputs:K38:9; "  ✗ "+$test.name+" ("+String:C10($test.duration)+"ms)"+$errorDetails+"\r\n"; Information message:K38:1)
                                         End if
                                 End if
                         End if

--- a/testing/Project/Sources/Classes/TestRunner.4dm
+++ b/testing/Project/Sources/Classes/TestRunner.4dm
@@ -130,9 +130,7 @@ Function _prepareSuites()
 Function _runSuitesSequentially()
 	This:C1470.results.startTime:=Milliseconds:C459
 	
-	If (This:C1470.outputFormat="human")
-		This:C1470._logHeader()
-	End if 
+	This:C1470._logHeader()
 	
 	var $testSuite : cs:C1710._TestSuite
 	For each ($testSuite; This:C1470.testSuites)
@@ -292,36 +290,30 @@ Function _collectSuiteResults($testSuite : cs:C1710._TestSuite)
 		If ($testResult.skipped)
 			This:C1470.results.skipped+=1
 			$suiteResult.skipped+=1
-			If (This:C1470.outputFormat="human")
-				LOG EVENT:C667(Into system standard outputs:K38:9; "  - "+$testResult.name+" (skipped)\r\n"; Information message:K38:1)
-			End if 
+			LOG EVENT:C667(Into system standard outputs:K38:9; "  - "+$testResult.name+" (skipped)\r\n"; Information message:K38:1)
 		Else 
 			If ($testResult.passed)
 				This:C1470.results.passed+=1
 				$suiteResult.passed+=1
-				If (This:C1470.outputFormat="human")
-					LOG EVENT:C667(Into system standard outputs:K38:9; "  ✓ "+$testResult.name+" ("+String:C10($testResult.duration)+"ms)\r\n"; Information message:K38:1)
-				End if 
+				LOG EVENT:C667(Into system standard outputs:K38:9; "  ✓ "+$testResult.name+" ("+String:C10($testResult.duration)+"ms)\r\n"; Information message:K38:1)
 			Else 
 				This:C1470.results.failed+=1
 				$suiteResult.failed+=1
 				This:C1470.results.failedTests.push($testResult)
-				If (This:C1470.outputFormat="human")
-					var $errorDetails : Text
-					$errorDetails:=""
-					If ($testResult.runtimeErrors.length>0)
-						$errorDetails:=" [Runtime Error: "+$testResult.runtimeErrors[0].text+"]"
-					Else 
-						If ($testResult.logMessages.length>0)
-							$errorDetails:=" ["+$testResult.logMessages[0]+"]"
-						End if 
+				var $errorDetails : Text
+				$errorDetails:=""
+				If ($testResult.runtimeErrors.length>0)
+					$errorDetails:=" [Runtime Error: "+$testResult.runtimeErrors[0].text+"]"
+				Else 
+					If ($testResult.logMessages.length>0)
+						$errorDetails:=" ["+$testResult.logMessages[0]+"]"
 					End if 
-					
+				End if 
+				
 				If (This:C1470.verboseOutput) && ($testResult.callChain#Null:C1517)
 					$errorDetails:=$errorDetails+"\r\n"+This:C1470._formatCallChain($testResult.callChain)
 				End if 
 				LOG EVENT:C667(Into system standard outputs:K38:9; "  ✗ "+$testResult.name+" ("+String:C10($testResult.duration)+"ms)"+$errorDetails+"\r\n"; Information message:K38:1)
-				End if 
 			End if 
 		End if 
 		
@@ -419,7 +411,8 @@ Function _groupGlobalErrors() : Object
 		If ($grouped[$key]=Null:C1517)
 			$grouped[$key]:=New object:C1471(\
 				"message"; This:C1470._formatGlobalErrorForLog($error); \
-				"count"; 1)
+				"count"; 1; \
+				"callChainJSON"; $error.callChainJSON || "")
 		Else 
 			$grouped[$key].count+=1
 		End if 
@@ -428,16 +421,22 @@ Function _groupGlobalErrors() : Object
 	return $grouped
 	
 Function _generateReport()
+	If (This:C1470.outputFormat#"none")
+		This:C1470._generateHumanReport()
+	End if 
+	
 	If (This:C1470.outputFormat="json")
 		This:C1470._generateJSONReport()
 	Else 
 		If (This:C1470.outputFormat="junit")
 			This:C1470._generateJUnitXMLReport()
-		Else 
-			If (This:C1470.outputFormat#"none")
-				This:C1470._generateHumanReport()
-			End if 
 		End if 
+	End if 
+	
+	If (This:C1470.hasFailed())
+		var $errorFile : 4D:C1709.File
+		$errorFile:=File:C1566(Structure file:C489(*); fk platform path:K87:2).parent.file("error")
+		$errorFile.setText("FAILED")
 	End if 
 	
 Function _generateHumanReport()
@@ -463,6 +462,14 @@ Function _generateHumanReport()
 			var $countSuffix : Text
 			$countSuffix:=($entry.count>1) ? " (x"+String:C10($entry.count)+")" : ""
 			LOG EVENT:C667(Into system standard outputs:K38:9; $entry.message+$countSuffix+"\r\n"; Information message:K38:1)
+			
+			If (This:C1470.callChainOutput) && ($entry.callChainJSON#"")
+				var $chain : Collection
+				$chain:=JSON Parse:C1218($entry.callChainJSON)
+				If ($chain#Null:C1517)
+					LOG EVENT:C667(Into system standard outputs:K38:9; This:C1470._formatCallChain($chain)+"\r\n"; Information message:K38:1)
+				End if 
+			End if 
 		End for each 
 	End if 
 	
@@ -621,8 +628,6 @@ Function _generateJSONReport()
 	
 	If ($outputPath#"")
 		This:C1470._writeJSONToFile($jsonString; $outputPath)
-	Else 
-		LOG EVENT:C667(Into system standard outputs:K38:9; $jsonString; Information message:K38:1)
 	End if 
 	
 Function _writeJSONToFile($jsonContent : Text; $outputPath : Text)
@@ -659,12 +664,13 @@ Function _buildJUnitXML() : Text
 	var $totalTime : Real
 	$totalTime:=This:C1470.results.duration/1000  // Convert ms to seconds
 	
-	// JUnit testsuites/@errors counts only TEST errors (failed tests with a runtime
-	// error). External (non-test) runtime errors live in <system-err>; including
-	// them here would inflate @errors and drive @failures negative.
 	var $totalErrors; $totalFailures : Integer
 	$totalErrors:=This:C1470._countTestsWithRuntimeErrors()
 	$totalFailures:=This:C1470.results.failed-$totalErrors  // assertion failures
+	
+	If (This:C1470.results.hasGlobalErrors)
+		$totalErrors:=$totalErrors+1
+	End if 
 	
 	// XML header and root testsuites element
 	$xml:="<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n"
@@ -868,29 +874,31 @@ Function _formatTimestamp($milliseconds : Integer) : Text
 	
 Function _logFooter()
 	LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
-	If ((This:C1470.results.failed=0) && Not:C34(This:C1470.results.hasGlobalErrors))
-		LOG EVENT:C667(Into system standard outputs:K38:9; "All tests passed! 🎉\r\n"; Information message:K38:1)
-	Else 
+	If (This:C1470.hasFailed())
 		var $summaryMessage : Text
-		$summaryMessage:=""
+		$summaryMessage:="FAILED: "
 		
+		var $parts : Collection
+		$parts:=New collection:C1472
 		If (This:C1470.results.failed>0)
-			$summaryMessage:=String:C10(This:C1470.results.failed)+" test(s) failed"
+			$parts.push(String:C10(This:C1470.results.failed)+" test(s) failed")
 		End if 
-		
 		If (This:C1470.results.hasGlobalErrors)
-			If ($summaryMessage#"")
-				$summaryMessage:=$summaryMessage+"; "
-			End if 
-			$summaryMessage:=$summaryMessage+String:C10(This:C1470.results.globalErrorCount)+" external runtime error(s)"
+			$parts.push(String:C10(This:C1470.results.globalErrorCount)+" external runtime error(s)")
 		End if 
+		$summaryMessage:=$summaryMessage+$parts.join(", ")
 		
 		LOG EVENT:C667(Into system standard outputs:K38:9; $summaryMessage+"\r\n"; Information message:K38:1)
+	Else 
+		LOG EVENT:C667(Into system standard outputs:K38:9; "All tests passed!\r\n"; Information message:K38:1)
 	End if 
 	LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
 	
 Function getResults() : Object
 	return This:C1470.results
+	
+Function hasFailed() : Boolean
+	return (This:C1470.results.failed>0) || This:C1470.results.hasGlobalErrors
 	
 Function _determineOutputFormat()
 	var $params : Object
@@ -902,6 +910,15 @@ Function _determineOutputFormat()
 		If ($params.format="junit") || ($params.format="xml")
 			This:C1470.outputFormat:="junit"
 		Else 
+			This:C1470.outputFormat:="human"
+		End if 
+	End if 
+	
+	If (This:C1470.outputFormat="json") || (This:C1470.outputFormat="junit")
+		var $outputPath : Text
+		$outputPath:=$params.outputPath || ""
+		If ($outputPath="")
+			LOG EVENT:C667(Into system standard outputs:K38:9; "Error: format="+This:C1470.outputFormat+" requires outputPath parameter\r\n"; Information message:K38:1)
 			This:C1470.outputFormat:="human"
 		End if 
 	End if 

--- a/testing/Project/Sources/Classes/TestRunner.4dm
+++ b/testing/Project/Sources/Classes/TestRunner.4dm
@@ -28,13 +28,9 @@ Function run()
 	This:C1470._prepareErrorHandlingStorage()
 	var $handlerState : Object
 	$handlerState:=This:C1470._installErrorHandler()
-	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] run: before _runInternal\r\n"; Information message:K38:1)
 	This:C1470._runInternal()
-	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] run: after _runInternal\r\n"; Information message:K38:1)
 	This:C1470._captureGlobalErrors()
-	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] run: after _captureGlobalErrors\r\n"; Information message:K38:1)
 	This:C1470._generateReport()
-	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] run: after _generateReport\r\n"; Information message:K38:1)
 	This:C1470._restoreErrorHandler($handlerState)
 	
 Function _determineTriggerDefaultBehavior()
@@ -139,15 +135,10 @@ Function _runSuitesSequentially()
 	End if 
 	
 	var $testSuite : cs:C1710._TestSuite
-	var $suiteIndex : Integer
-	$suiteIndex:=0
 	For each ($testSuite; This:C1470.testSuites)
-		$suiteIndex+=1
-		LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] suite "+String:C10($suiteIndex)+"/"+String:C10(This:C1470.testSuites.length)+": "+$testSuite.class.name+" ("+String:C10($testSuite.testFunctions.length)+" tests)\r\n"; Information message:K38:1)
 		$testSuite.run()
 		This:C1470._collectSuiteResults($testSuite)
 	End for each 
-	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _runSuitesSequentially: all suites done\r\n"; Information message:K38:1)
 	
 	This:C1470.results.endTime:=Milliseconds:C459
 	This:C1470.results.duration:=This:C1470.results.endTime-This:C1470.results.startTime
@@ -329,7 +320,7 @@ Function _collectSuiteResults($testSuite : cs:C1710._TestSuite)
 				If (This:C1470.verboseOutput) && ($testResult.callChain#Null:C1517)
 					$errorDetails:=$errorDetails+"\r\n"+This:C1470._formatCallChain($testResult.callChain)
 				End if 
-				LOG EVENT:C667(Into system standard outputs:K38:9; "  ✗ "+$testResult.name+" ("+String:C10($testResult.duration)+"ms)"+$errorDetails+"\r\n"; Error message:K38:3)
+				LOG EVENT:C667(Into system standard outputs:K38:9; "  ✗ "+$testResult.name+" ("+String:C10($testResult.duration)+"ms)"+$errorDetails+"\r\n"; Information message:K38:1)
 				End if 
 			End if 
 		End if 
@@ -416,8 +407,27 @@ Function _formatGlobalErrorForLog($error : Object) : Text
 	
 	return $message
 	
+Function _groupGlobalErrors() : Object
+	var $grouped : Object
+	$grouped:=New object:C1471
+	
+	var $error : Object
+	For each ($error; This:C1470.results.globalErrors)
+		var $key : Text
+		$key:=String:C10($error.code || 0)+"_"+($error.text || "")+"_"+String:C10($error.line || 0)
+		
+		If ($grouped[$key]=Null:C1517)
+			$grouped[$key]:=New object:C1471(\
+				"message"; This:C1470._formatGlobalErrorForLog($error); \
+				"count"; 1)
+		Else 
+			$grouped[$key].count+=1
+		End if 
+	End for each 
+	
+	return $grouped
+	
 Function _generateReport()
-	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateReport: format="+This:C1470.outputFormat+"\r\n"; Information message:K38:1)
 	If (This:C1470.outputFormat="json")
 		This:C1470._generateJSONReport()
 	Else 
@@ -429,10 +439,8 @@ Function _generateReport()
 			End if 
 		End if 
 	End if 
-	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateReport: done\r\n"; Information message:K38:1)
 	
 Function _generateHumanReport()
-	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateHumanReport: start\r\n"; Information message:K38:1)
 	var $passRate : Real
 	var $effectiveTotal : Integer
 	$effectiveTotal:=This:C1470.results.totalTests-This:C1470.results.skipped
@@ -444,17 +452,23 @@ Function _generateHumanReport()
 	
 	If (This:C1470.results.hasGlobalErrors)
 		LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
-		LOG EVENT:C667(Into system standard outputs:K38:9; "=== Runtime Errors Outside Test Processes ===\r\n"; Error message:K38:3)
+		LOG EVENT:C667(Into system standard outputs:K38:9; "=== Runtime Errors Outside Test Processes ===\r\n"; Information message:K38:1)
 		
-		var $globalError : Object
-		For each ($globalError; This:C1470.results.globalErrors)
-			LOG EVENT:C667(Into system standard outputs:K38:9; This:C1470._formatGlobalErrorForLog($globalError)+"\r\n"; Error message:K38:3)
+		var $grouped : Object
+		$grouped:=This:C1470._groupGlobalErrors()
+		var $key : Text
+		var $entry : Object
+		For each ($key; $grouped)
+			$entry:=$grouped[$key]
+			var $countSuffix : Text
+			$countSuffix:=($entry.count>1) ? " (x"+String:C10($entry.count)+")" : ""
+			LOG EVENT:C667(Into system standard outputs:K38:9; $entry.message+$countSuffix+"\r\n"; Information message:K38:1)
 		End for each 
 	End if 
 	
 	If (This:C1470.results.failed>0)
 		LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
-		LOG EVENT:C667(Into system standard outputs:K38:9; "=== Failed Tests ===\r\n"; Error message:K38:3)
+		LOG EVENT:C667(Into system standard outputs:K38:9; "=== Failed Tests ===\r\n"; Information message:K38:1)
 		
 		var $failedTest : Object
 		For each ($failedTest; This:C1470.results.failedTests)
@@ -469,10 +483,10 @@ Function _generateHumanReport()
 				End if 
 			End if 
 			
-			LOG EVENT:C667(Into system standard outputs:K38:9; "- "+$failedTest.name+$failureReason+"\r\n"; Error message:K38:3)
+			LOG EVENT:C667(Into system standard outputs:K38:9; "- "+$failedTest.name+$failureReason+"\r\n"; Information message:K38:1)
 			
 			If (This:C1470.verboseOutput) && ($failedTest.callChain#Null:C1517)
-				LOG EVENT:C667(Into system standard outputs:K38:9; This:C1470._formatCallChain($failedTest.callChain)+"\r\n"; Error message:K38:3)
+				LOG EVENT:C667(Into system standard outputs:K38:9; This:C1470._formatCallChain($failedTest.callChain)+"\r\n"; Information message:K38:1)
 			End if 
 		End for each 
 	End if 
@@ -487,14 +501,11 @@ Function _generateHumanReport()
 	LOG EVENT:C667(Into system standard outputs:K38:9; "Pass Rate: "+String:C10($passRate; "##0.0")+"%\r\n"; Information message:K38:1)
 	LOG EVENT:C667(Into system standard outputs:K38:9; "Duration: "+String:C10(This:C1470.results.duration)+"ms\r\n"; Information message:K38:1)
 	
-	var $externalMessageType : Integer
-	$externalMessageType:=Choose:C955(This:C1470.results.globalErrorCount>0; Error message:K38:3; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "External Errors: "+String:C10(This:C1470.results.globalErrorCount)+"\r\n"; $externalMessageType)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "External Errors: "+String:C10(This:C1470.results.globalErrorCount)+"\r\n"; Information message:K38:1)
 	
 	This:C1470._logFooter()
 	
 Function _generateJSONReport()
-	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateJSONReport: start, totalTests="+String:C10(This:C1470.results.totalTests)+"\r\n"; Information message:K38:1)
 	var $passRate : Real
 	var $effectiveTotal : Integer
 	$effectiveTotal:=This:C1470.results.totalTests-This:C1470.results.skipped
@@ -511,12 +522,10 @@ Function _generateJSONReport()
 	
 	If (This:C1470.verboseOutput)
 		// Verbose mode: include all details (original format)
-		LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateJSONReport: verbose OB Copy\r\n"; Information message:K38:1)
 		$jsonReport:=OB Copy:C1225(This:C1470.results)
 		$jsonReport.passRate:=$passRate
 		$jsonReport.status:=$hasFailures ? "failure" : "success"
 	Else 
-		LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateJSONReport: terse mode\r\n"; Information message:K38:1)
 		// Terse mode: minimal information
 		$jsonReport:=New object:C1471(\
 			"tests"; This:C1470.results.totalTests; \
@@ -604,14 +613,11 @@ Function _generateJSONReport()
 		End if 
 	End if 
 	
-	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateJSONReport: before JSON Stringify\r\n"; Information message:K38:1)
 	var $jsonString : Text
 	$jsonString:=JSON Stringify:C1217($jsonReport; *)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateJSONReport: after JSON Stringify, length="+String:C10(Length:C16($jsonString))+"\r\n"; Information message:K38:1)
 	
 	var $outputPath : Text
 	$outputPath:=This:C1470.userParams.outputPath || ""
-	LOG EVENT:C667(Into system standard outputs:K38:9; "[DEBUG] _generateJSONReport: outputPath='"+$outputPath+"'\r\n"; Information message:K38:1)
 	
 	If ($outputPath#"")
 		This:C1470._writeJSONToFile($jsonString; $outputPath)
@@ -789,9 +795,15 @@ Function _buildGlobalErrorsSystemErr() : Text
 	$xml:="  <system-err><![CDATA[\n"
 	$xml:=$xml+"External runtime errors detected: "+String:C10(This:C1470.results.globalErrorCount)+"\n"
 	
-	var $error : Object
-	For each ($error; This:C1470.results.globalErrors)
-		$xml:=$xml+This:C1470._formatGlobalErrorForLog($error)+"\n"
+	var $grouped : Object
+	$grouped:=This:C1470._groupGlobalErrors()
+	var $key : Text
+	var $entry : Object
+	For each ($key; $grouped)
+		$entry:=$grouped[$key]
+		var $countSuffix : Text
+		$countSuffix:=($entry.count>1) ? " (x"+String:C10($entry.count)+")" : ""
+		$xml:=$xml+$entry.message+$countSuffix+"\n"
 	End for each 
 	
 	$xml:=$xml+"]]></system-err>\r\n"
@@ -873,7 +885,7 @@ Function _logFooter()
 			$summaryMessage:=$summaryMessage+String:C10(This:C1470.results.globalErrorCount)+" external runtime error(s)"
 		End if 
 		
-		LOG EVENT:C667(Into system standard outputs:K38:9; $summaryMessage+"\r\n"; Error message:K38:3)
+		LOG EVENT:C667(Into system standard outputs:K38:9; $summaryMessage+"\r\n"; Information message:K38:1)
 	End if 
 	LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
 	

--- a/testing/Project/Sources/Classes/TestRunner.4dm
+++ b/testing/Project/Sources/Classes/TestRunner.4dm
@@ -442,19 +442,15 @@ Function _generateHumanReport()
 		$passRate:=0
 	End if 
 	
-	LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "=== Test Results Summary ===\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "Total Tests: "+String:C10(This:C1470.results.totalTests)+"\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "Passed: "+String:C10(This:C1470.results.passed)+"\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "Failed: "+String:C10(This:C1470.results.failed)+"\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "Skipped: "+String:C10(This:C1470.results.skipped)+"\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "Assertions: "+String:C10(This:C1470.results.assertions)+"\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "Pass Rate: "+String:C10($passRate; "##0.0")+"%\r\n"; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "Duration: "+String:C10(This:C1470.results.duration)+"ms\r\n"; Information message:K38:1)
-	
-	var $externalMessageType : Integer
-	$externalMessageType:=Choose:C955(This:C1470.results.globalErrorCount>0; Error message:K38:3; Information message:K38:1)
-	LOG EVENT:C667(Into system standard outputs:K38:9; "External Errors: "+String:C10(This:C1470.results.globalErrorCount)+"\r\n"; $externalMessageType)
+	If (This:C1470.results.hasGlobalErrors)
+		LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
+		LOG EVENT:C667(Into system standard outputs:K38:9; "=== Runtime Errors Outside Test Processes ===\r\n"; Error message:K38:3)
+		
+		var $globalError : Object
+		For each ($globalError; This:C1470.results.globalErrors)
+			LOG EVENT:C667(Into system standard outputs:K38:9; This:C1470._formatGlobalErrorForLog($globalError)+"\r\n"; Error message:K38:3)
+		End for each 
+	End if 
 	
 	If (This:C1470.results.failed>0)
 		LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
@@ -481,15 +477,19 @@ Function _generateHumanReport()
 		End for each 
 	End if 
 	
-	If (This:C1470.results.hasGlobalErrors)
-		LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
-		LOG EVENT:C667(Into system standard outputs:K38:9; "=== Runtime Errors Outside Test Processes ===\r\n"; Error message:K38:3)
-		
-		var $globalError : Object
-		For each ($globalError; This:C1470.results.globalErrors)
-			LOG EVENT:C667(Into system standard outputs:K38:9; This:C1470._formatGlobalErrorForLog($globalError)+"\r\n"; Error message:K38:3)
-		End for each 
-	End if 
+	LOG EVENT:C667(Into system standard outputs:K38:9; "\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "=== Test Results Summary ===\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "Total Tests: "+String:C10(This:C1470.results.totalTests)+"\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "Passed: "+String:C10(This:C1470.results.passed)+"\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "Failed: "+String:C10(This:C1470.results.failed)+"\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "Skipped: "+String:C10(This:C1470.results.skipped)+"\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "Assertions: "+String:C10(This:C1470.results.assertions)+"\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "Pass Rate: "+String:C10($passRate; "##0.0")+"%\r\n"; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "Duration: "+String:C10(This:C1470.results.duration)+"ms\r\n"; Information message:K38:1)
+	
+	var $externalMessageType : Integer
+	$externalMessageType:=Choose:C955(This:C1470.results.globalErrorCount>0; Error message:K38:3; Information message:K38:1)
+	LOG EVENT:C667(Into system standard outputs:K38:9; "External Errors: "+String:C10(This:C1470.results.globalErrorCount)+"\r\n"; $externalMessageType)
 	
 	This:C1470._logFooter()
 	

--- a/testing/Resources/en.lproj/syntaxEN.json
+++ b/testing/Resources/en.lproj/syntaxEN.json
@@ -696,6 +696,17 @@
 		}
 	},
 	"TestRunner": {
+		"hasFailed()": {
+			"Syntax": "**.hasFailed**() : Boolean",
+			"Params": [
+				[
+					"",
+					"Boolean",
+					"<-"
+				]
+			],
+			"Summary": ""
+		},
 		"getResults()": {
 			"Syntax": "**.getResults**() : Object",
 			"Params": [


### PR DESCRIPTION
## Summary

This PR improves the test framework's output behavior, failure detection, and error reporting:

### Output Behavior Changes
- **Human-readable output always streams to stdout** regardless of `format` parameter — you always see real-time test progress
- **`format=json` and `format=junit` now require `outputPath`** — report is written to file only, never dumped to stdout
- If `outputPath` is omitted for json/junit, the framework prints an error and falls back to human-only output
- Removed the JSON stdout fallback path entirely

### Failure Detection & Exit Codes
- Added `hasFailed()` method: returns true when any tests fail OR external runtime errors are detected
- Framework writes an `error` file when `hasFailed()` is true, which the Makefile checks to exit non-zero
- `make test` now exits with code 1 on any failure (test failures or external runtime errors)
- Clear "FAILED: X test(s) failed, Y external runtime error(s)" banner in human output
- JUnit XML `<testsuites>` `errors` count incremented by 1 when external errors exist, ensuring CI tools correctly flag the run

### Call Chain Support for External Errors
- When `callchain=true` or `verbose=true` is set, external runtime error call stacks are now displayed in the human report
- `_groupGlobalErrors` preserves `callChainJSON` from the first error in each deduplicated group
- Call chains are formatted using the existing `_formatCallChain` utility

### Makefile Improvements
- Added `PROJECT_DIR` and `ERROR_FILE` variables for error file detection
- All json/junit targets now include explicit `outputPath` parameter
- FIFO-based cooperative-yield noise filtering (real-time, no buffering)
- Robust Ctrl+C handling with `disown` to suppress "Killed: 9" messages

### Documentation
- Updated CLAUDE.md and AGENTS.md with new `outputPath` requirement in all examples
- Added "Output Behavior" section explaining streaming, file output, and exit code semantics

## Test Plan

1. **Basic test run** — verify human output streams in real-time:
   ```bash
   make test test=_ExampleTest
   ```
   Expected: real-time ✓/✗ output, "All tests passed!" at end, exit 0

2. **JSON output requires outputPath**:
   ```bash
   make test format=json
   ```
   Expected: error message about missing outputPath, falls back to human output

3. **JSON output with outputPath**:
   ```bash
   make test format=json outputPath=test-results/report.json test=_ExampleTest
   ```
   Expected: human output streams to stdout AND json written to file

4. **Failure detection with external errors** (requires host project with runtime errors):
   ```bash
   make test  # in a host project with external errors
   ```
   Expected: "FAILED: N external runtime error(s)" banner, exit code 1

5. **Call chain display for external errors**:
   ```bash
   make test callchain=true  # in host project with external errors
   ```
   Expected: each grouped external error shows its "Call Stack:" with method names and line numbers

6. **Call chains hidden by default**:
   ```bash
   make test  # without callchain=true or verbose=true
   ```
   Expected: external errors listed without call stacks

7. **JUnit XML failure flag**:
   ```bash
   make test format=junit outputPath=test-results/junit.xml
   ```
   Expected: if external errors exist, `<testsuites errors="N">` where N > 0

8. **Ctrl+C handling**:
   ```bash
   make test  # then press Ctrl+C during execution
   ```
   Expected: immediate termination, no "Killed: 9" messages, exit code 130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `debug=true` option to show tool stderr during tests.
  * New make targets provide default JSON/JUnit report file locations.

* **Improvements**
  * JSON/JUnit modes now require an outputPath and write reports to files only.
  * Console output cleans up noisy warnings; runtime/global errors are grouped and shown more readably.
  * Summary/failure lines are presented as informational (cleaner console severity).

* **Documentation**
  * Updated docs with examples and notes for JSON/JUnit output, outputPath, and debugging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KyleKincer/testing/pull/32)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->